### PR TITLE
Prevent network overlaps between L1 and L2 dockerd instances

### DIFF
--- a/tests/scr/testContainerInit
+++ b/tests/scr/testContainerInit
@@ -58,7 +58,14 @@ if [ -z "$SHIFT_UIDS" ]; then
             "path": "/usr/local/sbin/sysbox-runc"
         }
     },
-    "default-runtime": "sysbox-runc"
+    "default-runtime": "sysbox-runc",
+    "bip": "172.24.0.1/16",
+    "default-address-pools": [
+        {
+            "base": "172.31.0.0/16",
+            "size": 24
+        }
+    ]
 }
 EOF
 else
@@ -75,7 +82,14 @@ else
             ]
         }
     },
-    "default-runtime": "sysbox-runc"
+    "default-runtime": "sysbox-runc",
+    "bip": "172.24.0.1/16",
+    "default-address-pools": [
+        {
+            "base": "172.31.0.0/16",
+            "size": 24
+        }
+    ]
 }
 EOF
 fi


### PR DESCRIPTION
Problem may impact the Sysbox testing framework during the execution of its test-suites. The subnet allocated by dockerd at level-1 (within the privileged test container), may overlap with the docker0 subnet allocated by dockerd at level-2.

To avoid this potential overlap, we are explicitly defining the network ranges to utilize at level-1, so that they don't collide with docker's default 172.17/16 -- 172.18/16 range, which would be the one used at level-2.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>