### PR TITLE
Extended recent MTU fix to avoid testcase failures in specific scenarios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,8 @@ test-sysbox: ## Run sysbox integration tests
 test-sysbox: test-img
 	@printf "\n** Running sysbox integration tests **\n\n"
 	$(TEST_DIR)/scr/testContainerPre $(TEST_VOL1) $(TEST_VOL2) $(TEST_VOL3)
-	$(DOCKER_RUN) /bin/bash -c "testContainerInit && make test-sysbox-local TESTPATH=$(TESTPATH)"
+	$(DOCKER_RUN) /bin/bash -c "export PHY_EGRESS_IFACE_MTU=$(EGRESS_IFACE_MTU) && \
+		testContainerInit && make test-sysbox-local TESTPATH=$(TESTPATH)"
 
 test-sysbox-shiftuid: ## Run sysbox integration tests with uid-shifting (shiftfs)
 test-sysbox-shiftuid: test-img
@@ -229,7 +230,9 @@ ifeq ($(SHIFTUID_ON), )
 else
 	@printf "\n** Running sysbox integration tests (with uid shifting) **\n\n"
 	$(TEST_DIR)/scr/testContainerPre $(TEST_VOL1) $(TEST_VOL2) $(TEST_VOL3)
-	$(DOCKER_RUN) /bin/bash -c "export SHIFT_UIDS=true && testContainerInit && make test-sysbox-local TESTPATH=$(TESTPATH)"
+	$(DOCKER_RUN) /bin/bash -c "export PHY_EGRESS_IFACE_MTU=$(EGRESS_IFACE_MTU) && \
+		export SHIFT_UIDS=true && testContainerInit && \
+		make test-sysbox-local TESTPATH=$(TESTPATH)"
 endif
 
 test-runc: ## Run sysbox-runc unit & integration tests
@@ -250,12 +253,14 @@ test-mgr: test-img
 test-shell: ## Get a shell in the test container (useful for debug)
 test-shell: test-img
 	$(TEST_DIR)/scr/testContainerPre $(TEST_VOL1) $(TEST_VOL2) $(TEST_VOL3)
-	$(DOCKER_RUN) /bin/bash -c "testContainerInit && /bin/bash"
+	$(DOCKER_RUN) /bin/bash -c "export PHY_EGRESS_IFACE_MTU=$(EGRESS_IFACE_MTU) && \
+		testContainerInit && /bin/bash"
 
 test-shell-shiftuid: ## Get a shell in the test container with uid-shifting
 test-shell-shiftuid: test-img
 	$(TEST_DIR)/scr/testContainerPre $(TEST_VOL1) $(TEST_VOL2) $(TEST_VOL3)
-	$(DOCKER_RUN) /bin/bash -c "export SHIFT_UIDS=true && testContainerInit && /bin/bash"
+	$(DOCKER_RUN) /bin/bash -c "export PHY_EGRESS_IFACE_MTU=$(EGRESS_IFACE_MTU) && \
+		export SHIFT_UIDS=true && testContainerInit && /bin/bash"
 
 test-img: ## Build test container image
 test-img:

--- a/tests/scr/testContainerInit
+++ b/tests/scr/testContainerInit
@@ -10,7 +10,7 @@ dockerCfgDir="/etc/docker"
 dockerCfgFile="${dockerCfgDir}/daemon.json"
 
 # Default mtu value associated to test-container's egress-interface.
-export default_mtu=1500
+default_mtu=1500
 
 # Temp file for jq write operations.
 tmpfile=$(mktemp /tmp/init-scr.XXXXXX)
@@ -39,22 +39,42 @@ function retry() {
   false
 }
 
-function egress_iface_mtu() {
+#
+# Obtain the MTU value to be configured for the docker interface within the test
+# container. This value shall be the lowest among these ...
+#
+#  * The 'physical' default-gateway interface at host level (L0).
+#  * The 'logical' default-gateway interface connecting the test-container (L1) with the host.
+#  * The 'default' mtu value (1500 bytes) supported by most NICs.
+#
+function docker_iface_mtu() {
+
+    local egress_iface
+    local l0_egress_mtu
+    local l1_egress_mtu
 
     # Identify default egress iface.
     local egress_iface=$(ip route show | awk '/default via/ {print $5}')
-    if [ ! -z "${egress_iface}" ]; then
-	echo ${default_mtu}
+    if [ -z "${egress_iface}" ]; then
 	return
     fi
 
-    # Obtain mtu value associated to egress interface, and return it
-    # if this one is lower than default value.
-    local egress_mtu=$(ip link show ${egress_iface} | awk '/mtu / {print $5}')
-    if [ ! -z "${egress_mtu}" ] && [ "${egress_mtu}" -lt 1500 ]; then
-	echo ${egress_mtu}
+    # Obtain mtu value associated to the test-container's egress interface.
+    egress_mtu=$(ip link show ${egress_iface} | awk '/mtu / {print $5}')
+    if [ ! -z "${egress_mtu}" ] &&
+       [ "${egress_mtu}" -lt "${default_mtu}" ]; then
+	l1_egress_mtu=${egress_mtu}
     else
-	echo ${default_mtu}
+	l1_egress_mtu=${default_mtu}
+    fi
+
+    # Pull L0 egress-mtu value passed from Sysbox's makefile.
+    l0_egress_mtu=${PHY_EGRESS_IFACE_MTU}
+
+    if [ "${l0_egress_mtu}" -lt "${l1_egress_mtu}" ]; then
+	echo ${l0_egress_mtu}
+    else
+	echo ${l1_egress_mtu}
     fi
 }
 
@@ -127,9 +147,9 @@ fi
 
 # Adjust docker's interface mtu configuration. This is required to avoid forwarding issues
 # in containers seating behind an egress-interface with lower-than-default mtu.
-egress_mtu=$(egress_iface_mtu)
-if [ ${egress_mtu} -ne ${default_mtu} ]; then
-    jq --arg mtu ${egress_mtu} --indent 4 '. + {"mtu": $mtu}' "${dockerCfgFile}" \
+egress_mtu=$(docker_iface_mtu)
+if [ ! -z "${egress_mtu}" ] && [ "${egress_mtu}" -ne "${default_mtu}" ]; then
+    jq --arg mtu "${egress_mtu}" --indent 4 '. + {"mtu": $mtu|tonumber}' "${dockerCfgFile}" \
        > ${tmpfile} && cp ${tmpfile} "${dockerCfgFile}"
 fi
 
@@ -145,3 +165,4 @@ make sysbox-local --no-print-directory && make install
 echo "Starting sysbox with test-specific options"
 install -D -m0755 tests/scr/sysbox /usr/local/sbin/sysbox
 sysbox
+


### PR DESCRIPTION
The specific scenarios i'm referring to are those in which the 'physical' (L0) egress interface holds an MTU value that is lower than the typical 1500 bytes (usual case in GCP -- 1460 bytes).

Signed-off-by: Rodny Molina <rmolina@nestybox.com>