### PR TITLE
Initial Travis CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+dist: bionic
+group: edge
+
+language: go
+
+git:
+  submodules: false
+
+before_install:
+  # Install recent docker package.
+  - sudo apt-get update && sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - apt-key fingerprint 0EBFCD88
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+
+  # Install linux-kernel-headers package.
+  - sudo apt-get install linux-headers-$(uname -r)
+
+  # For parent repos (i.e. sysbox, sysbox-fs, sysbox-libs), let's avoid dealing with ssh-keys mess by simply replacing their
+  # ssh url with an http one.
+  - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+  - git submodule update --init
+  - sed -i 's/git@github.com:/https:\/\/github.com\//' sysbox-fs/.gitmodules
+  - sed -i 's/git@github.com:/https:\/\/github.com\//' sysbox-libs/.gitmodules
+  - git -C sysbox-fs submodule update --init
+  - git -C sysbox-libs submodule update --init
+
+script:
+  - make sysbox
+  - make test-sysbox-ci
+  - make test-sysbox-shiftuid-ci

--- a/tests/scr/testSysboxCI
+++ b/tests/scr/testSysboxCI
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+
+#
+# script to run sysbox integration tests for continous-integration purposes
+#
+
+progName=$(basename "$0")
+
+usage()
+{
+  echo "
+Usage: $progName <testName>
+
+"
+  exit 1
+}
+
+# argument testName is optional
+if [ $# -eq 1 ]; then
+  printf "\nExecuting $1 ... \n"
+  bats --tap $1
+else
+  printf "\nExecuting sysbox-mgr tests ... \n"
+  bats --tap tests/sysmgr
+  printf "\nExecuting sysbox-fs tests ... \n"
+  bats --tap tests/sysfs
+  printf "\nExecuting docker tests ... \n"
+  bats --tap tests/docker
+  printf "\nExecuting dind tests ... \n"
+  bats --tap tests/dind
+  printf "\nExecuting cind tests ... \n"
+  bats --tap tests/cind
+  printf "\nExecuting app tests (l1) ... \n"
+  bats --tap tests/apps/l1
+
+  # the kind tests need plenty storage (otherwise kubelet fails);
+  # remove all docker images from prior tests to make room
+  docker system prune -a -f
+
+  printf "\nExecuting kind tests ... \n"
+  bats --tap tests/kind/kindbox-custom-net.bats
+
+  # Note: this must be the last test
+  printf "\nSysbox health checking ...\n"
+  bats --tap tests/health/sysbox-health.bats
+
+  docker system prune -a -f
+fi
+
+exit 0


### PR DESCRIPTION
As part of this PR i'm creating a Travis CI pipeline and adding two new Makefile targets for this purpose. The execution of all Sysbox-CE's testsuites would take ~ 90 mins (2 cores, 8GB VM), so these dedicated targets will serve us to launch a smaller subset of testcases to keep the entire cycle under ~ 40mins length.