### PR TITLE
Mount the host kernel's seccomp.h header to the test container.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ DOCKER_SYSBOX_BLD := docker run --privileged --rm                     \
 			-v /lib/modules/$(KERNEL_REL):/lib/modules/$(KERNEL_REL):ro \
 			-v /usr/src/$(HEADERS):/usr/src/$(HEADERS):ro \
 			-v /usr/src/$(HEADERS_BASE):/usr/src/$(HEADERS_BASE):ro \
+			-v /usr/include/linux/seccomp.h:/usr/include/linux/seccomp.h:ro \
 			$(TEST_IMAGE)
 
 sysbox: ## Build sysbox
@@ -208,8 +209,8 @@ DOCKER_RUN := docker run -it --privileged --rm                        \
 			-v /lib/modules/$(KERNEL_REL):/lib/modules/$(KERNEL_REL):ro \
 			-v /usr/src/$(HEADERS):/usr/src/$(HEADERS):ro \
 			-v /usr/src/$(HEADERS_BASE):/usr/src/$(HEADERS_BASE):ro \
+			-v /usr/include/linux/seccomp.h:/usr/include/linux/seccomp.h:ro \
 			$(TEST_IMAGE)
-
 
 ##@ Testing targets
 
@@ -351,7 +352,7 @@ clean:
 
 clean_libseccomp: ## Clean libseccomp
 clean_libseccomp:
-	cd $(LIBSECCOMP_DIR) && sudo make clean
+	cd $(LIBSECCOMP_DIR) && sudo make distclean
 
 # memoize all packages once
 


### PR DESCRIPTION
The seccomp.h header (/usr/include/linux/seccomp.h) in the test container
may not always match that of the host kernel, leading to problems when
building the libseccomp C library inside the test container. This
library is used by libseccomp-golang which is in turn used by
Sysbox, causing problems for Sysbox.

For example, I found out that Sysbox was not working correctly when libseccomp
was built inside the container image on my Ubuntu focal host. But it was working
correctly when libseccomp was build at host level.

After debugging, I found out that a recent change in the Ubuntu focal kernel
updated the definition of symbol SECCOMP_IOCTL_NOTIF_ID_VALID in the kernel:

"
commit a11e5a541ab1f7ac4216783f032017983f582b95
Author: Kees Cook <keescook@chromium.org>
Date:   Mon Jun 15 15:42:46 2020 -0700

    seccomp: Fix ioctl number for SECCOMP_IOCTL_NOTIF_ID_VALID

...

-#define SECCOMP_IOCTL_NOTIF_ID_VALID   SECCOMP_IOR(2, __u64)
+#define SECCOMP_IOCTL_NOTIF_ID_VALID   SECCOMP_IOW(2, __u64)
"

This change went into the Ubuntu focal 5.4.0-47 version, and the seccomp.h
header file inside the sysbox test container has the updated definition
(because it's based on the ubuntu:latest docker image).

However, my host has an earlier kernel (5.4.0-45). As a result, the seccomp.h
with the updated definition in the test container does not work on my older
kernel.

To work-around this, I am mounting into the sysbox test container the
seccomp.h file from the host. This way, the file will match the host's kernel
definitions. I verfified that with this change, it's possible to build
libseccomp inside the test container and things work fine.