### PR TITLE
Simple adjustment in docker's integration-testsuite to eliminate redundant containers

### DIFF
--- a/tests/docker/mounts.bats
+++ b/tests/docker/mounts.bats
@@ -265,11 +265,10 @@ function teardown() {
   local syscont=$(docker_run --rm --mount type=bind,source=${testDir},target=/var/lib/docker nestybox/alpine-docker-dbg:latest tail -f /dev/null)
 
   # This docker run is expected to pass but generate a warning (multiple containers can (but should not) share the same /var/lib/docker mount source)
-  run __docker run --runtime=sysbox-runc -d --rm --mount type=bind,source=${testDir},target=/var/lib/docker nestybox/alpine-docker-dbg:latest tail -f /dev/null
-  [ "$status" -eq 0 ]
-
+  local syscont_2=$(docker_run --rm --mount type=bind,source=${testDir},target=/var/lib/docker nestybox/alpine-docker-dbg:latest tail -f /dev/null)
   egrep -q "WARN.+ mount source.+should be mounted in one container only" $SYSBOX_MGR_LOG
 
+  docker_stop "$syscont_2"
   docker_stop "$syscont"
 
   sleep 2
@@ -405,11 +404,10 @@ function teardown() {
   local syscont=$(docker_run --rm --mount type=bind,source=${testDir},target=/var/lib/kubelet nestybox/alpine-docker-dbg:latest tail -f /dev/null)
 
   # This docker run is expected to pass but generate a warning (multiple containers can (but should not) share the same /var/lib/docker mount source)
-  run __docker run --runtime=sysbox-runc -d --rm --mount type=bind,source=${testDir},target=/var/lib/kubelet nestybox/alpine-docker-dbg:latest tail -f /dev/null
-  [ "$status" -eq 0 ]
-
+  local syscont_2=$(docker_run --rm --mount type=bind,source=${testDir},target=/var/lib/kubelet nestybox/alpine-docker-dbg:latest tail -f /dev/null)
   egrep -q "WARN.+ mount source.+should be mounted in one container only" $SYSBOX_MGR_LOG
 
+  docker_stop "$syscont_2"
   docker_stop "$syscont"
 
   sleep 2

--- a/tests/scr/testSysbox
+++ b/tests/scr/testSysbox
@@ -40,6 +40,7 @@ else
   # the kind tests need plenty storage (otherwise kubelet fails);
   # remove all docker images from prior tests to make room, and
   # remove all docker images after test too.
+  printf "\n"
   docker system prune -a -f
   printf "\nExecuting kind tests ... \n"
   bats --tap tests/kind
@@ -48,7 +49,6 @@ else
   printf "\nExecuting perf tests ... \n"
   bats --tap tests/perf
 
-  # Note: this must be the last test
   printf "\nSysbox health checking ...\n"
   bats --tap tests/health/sysbox-health.bats
 

--- a/tests/scr/testSysboxCI
+++ b/tests/scr/testSysboxCI
@@ -34,13 +34,14 @@ else
   bats --tap tests/apps/l1
 
   # the kind tests need plenty storage (otherwise kubelet fails);
-  # remove all docker images from prior tests to make room
+  # remove all docker images from prior tests to make room, and
+  # remove all docker images after test too.
+  printf "\n"
   docker system prune -a -f
-
   printf "\nExecuting kind tests ... \n"
   bats --tap tests/kind/kindbox-custom-net.bats
+  docker system prune -a -f
 
-  # Note: this must be the last test
   printf "\nSysbox health checking ...\n"
   bats --tap tests/health/sysbox-health.bats
 


### PR DESCRIPTION
This one was recently introduced as part of sysbox-mgr's [PR #9](https://github.com/nestybox/sysbox-mgr/pull/7), which prevented sysbox-health integration checkpoints to succeed due to a couple of sys-containers being left out.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>