### PR TITLE
Correct and enhance kernel-headers integration testcases

### DIFF
--- a/tests/helpers/fs.bash
+++ b/tests/helpers/fs.bash
@@ -87,7 +87,7 @@ function selinux_on() {
 }
 
 # Returns linux distro running on the host (technically, in the test-priv container).
-function get_distro() {
+function get_host_distro() {
 
   local distro=$(cat /etc/os-release | awk -F"=" '/^ID=/ {print $2}' | tr -d '"')
 

--- a/tests/helpers/fs.bash
+++ b/tests/helpers/fs.bash
@@ -85,3 +85,11 @@ function selinux_on() {
     return 1
   fi
 }
+
+# Returns linux distro running on the host (technically, in the test-priv container).
+function get_distro() {
+
+  local distro=$(cat /etc/os-release | awk -F"=" '/^ID=/ {print $2}' | tr -d '"')
+
+  echo $distro
+}

--- a/tests/sysmgr/mount.bats
+++ b/tests/sysmgr/mount.bats
@@ -5,6 +5,7 @@
 #
 
 load ../helpers/run
+load ../helpers/fs
 load ../helpers/sysbox-health
 
 # verify sys container has a mount for /lib/modules/<kernel>
@@ -25,19 +26,97 @@ load ../helpers/sysbox-health
   docker_stop "$syscont"
 }
 
-# verify sys container has a mount for /usr/src/linux-headers-<kernel>
-@test "kernel headers mounts" {
+# Verify that Ubuntu sys container has kernel-headers in the expected path.
+@test "kernel headers mounts (ubuntu)" {
 
   local kernel_rel=$(uname -r)
-  local syscont=$(docker_run --rm nestybox/alpine-docker-dbg:latest tail -f /dev/null)
+  local distro=$(get_distro)
 
-  docker exec "$syscont" sh -c "mount | grep \"/usr/src/linux-headers-${kernel_rel}\""
-  [ "$status" -eq 0 ]
+  local syscont=$(docker_run --rm ubuntu:bionic tail -f /dev/null)
 
-  if [ -n "$SHIFT_UIDS" ]; then
-    [[ "${lines[0]}" =~ "/usr/src/linux-headers-${kernel_rel} on /usr/src/linux-headers-${kernel_rel} type shiftfs".+"ro".+"relatime" ]]
-  else
-    [[ "${lines[0]}" =~ "on /usr/src/linux-headers-${kernel_rel}".+"ro".+"relatime" ]]
+  # Expected behavior will vary depending on the linux-distro running on the
+  # host (i.e. test-priv container).
+  if [[ "${distro}" == "centos" ]] ||
+      [[ "${distro}" == "fedora" ]] ||
+      [[ "${distro}" == "redhat" ]]; then
+
+      docker exec "$syscont" sh -c "mount | grep \"/usr/src/kernels/${kernel_rel}\""
+      [ "$status" -eq 0 ]
+
+      if [ -n "$SHIFT_UIDS" ]; then
+         [[ "${lines[0]}" =~ "/usr/src/kernels/${kernel_rel} on /usr/src/kernels/${kernel_rel} type shiftfs".+"ro".+"relatime" ]]
+      else
+        [[ "${lines[0]}" =~ "on /usr/src/kernels/${kernel_rel}".+"ro".+"relatime" ]]
+      fi
+
+      # Verify that /usr/src/linux-headers-$kernel_rel --> /usr/src/kernels/$kernel_rel
+      # softlink has been created in ubuntu's kernel-headers expected path.
+      docker exec "$syscont" sh -c "stat /usr/src/linux-headers-${kernel_rel} | egrep -q \"symbolic\""
+      [ "$status" -eq 0 ]
+
+ else
+      docker exec "$syscont" sh -c "mount | grep \"/usr/src/linux-headers-${kernel_rel}\""
+      [ "$status" -eq 0 ]
+
+      if [ -n "$SHIFT_UIDS" ]; then
+         [[ "${lines[0]}" =~ "/usr/src/linux-headers-${kernel_rel} on /usr/src/linux-headers-${kernel_rel} type shiftfs".+"ro".+"relatime" ]]
+      else
+        [[ "${lines[0]}" =~ "on /usr/src/linux-headers-${kernel_rel}".+"ro".+"relatime" ]]
+      fi
+
+      # Verify that no /usr/src/linux-headers-$kernel_rel --> /usr/src/kernels/$kernel_rel
+      # softlink has been created -- shouldn't be needed in this case as sysbox-runc/mgr
+      # already bind-mounts all the required paths.
+      docker exec "$syscont" sh -c "stat /usr/src/linux-headers-${kernel_rel} | egrep -q \"symbolic\""
+      [ "$status" -eq 1 ]
+  fi
+
+  docker_stop "$syscont"
+}
+
+# Verify that Fedora sys container has kernel-headers in the expected path.
+@test "kernel headers mounts (fedora)" {
+
+  local kernel_rel=$(uname -r)
+  local distro=$(get_distro)
+
+  local syscont=$(docker_run --rm fedora:31 tail -f /dev/null)
+
+  # Expected behavior will vary depending on the linux-distro running on the
+  # host (i.e. test-priv container).
+  if [[ "${distro}" == "centos" ]] ||
+      [[ "${distro}" == "fedora" ]] ||
+      [[ "${distro}" == "redhat" ]]; then
+
+      docker exec "$syscont" sh -c "mount | grep \"/usr/src/kernels/${kernel_rel}\""
+      [ "$status" -eq 0 ]
+
+      if [ -n "$SHIFT_UIDS" ]; then
+        [[ "${lines[0]}" =~ "/usr/src/kernels/${kernel_rel} on /usr/src/kernels/${kernel_rel} type shiftfs".+"ro".+"relatime" ]]
+      else
+        [[ "${lines[0]}" =~ "on /usr/src/kernels/${kernel_rel}".+"ro".+"relatime" ]]
+      fi
+
+      # Verify that no /usr/src/linux-headers-$kernel_rel --> /usr/src/kernels/$kernel_rel
+      # softlink has been created -- shouldn't be needed in this case as sysbox-runc/mgr
+      # already bind-mount all required paths.
+      docker exec "$syscont" sh -c "stat /usr/src/linux-headers-${kernel_rel} | egrep -q \"symbolic\""
+      [ "$status" -eq 1 ]
+
+ else
+      docker exec "$syscont" sh -c "mount | grep \"/usr/src/linux-headers-${kernel_rel}\""
+      [ "$status" -eq 0 ]
+
+      if [ -n "$SHIFT_UIDS" ]; then
+         [[ "${lines[0]}" =~ "/usr/src/linux-headers-${kernel_rel} on /usr/src/linux-headers-${kernel_rel} type shiftfs".+"ro".+"relatime" ]]
+      else
+        [[ "${lines[0]}" =~ "on /usr/src/linux-headers-${kernel_rel}".+"ro".+"relatime" ]]
+      fi
+
+      # Verify that /usr/src/kernels/linux-headers-$kernel_rel --> /usr/src/kernels/$kernel_rel
+      # softlink has been created in fedora's kernel-headers expected path).
+      docker exec "$syscont" sh -c "stat /usr/src/kernels/${kernel_rel} | egrep -q \"symbolic\""
+      [ "$status" -eq 0 ]
   fi
 
   docker_stop "$syscont"

--- a/tests/sysmgr/mount.bats
+++ b/tests/sysmgr/mount.bats
@@ -30,7 +30,7 @@ load ../helpers/sysbox-health
 @test "kernel headers mounts (ubuntu)" {
 
   local kernel_rel=$(uname -r)
-  local distro=$(get_distro)
+  local distro=$(get_host_distro)
 
   local syscont=$(docker_run --rm ubuntu:bionic tail -f /dev/null)
 
@@ -65,7 +65,7 @@ load ../helpers/sysbox-health
       fi
 
       # Verify that no /usr/src/linux-headers-$kernel_rel --> /usr/src/kernels/$kernel_rel
-      # softlink has been created -- shouldn't be needed in this case as sysbox-runc/mgr
+      # softlink has been created -- it's not needed in this case as sysbox-runc/mgr
       # already bind-mounts all the required paths.
       docker exec "$syscont" sh -c "stat /usr/src/linux-headers-${kernel_rel} | egrep -q \"symbolic\""
       [ "$status" -eq 1 ]
@@ -78,7 +78,7 @@ load ../helpers/sysbox-health
 @test "kernel headers mounts (fedora)" {
 
   local kernel_rel=$(uname -r)
-  local distro=$(get_distro)
+  local distro=$(get_host_distro)
 
   local syscont=$(docker_run --rm fedora:31 tail -f /dev/null)
 
@@ -98,8 +98,8 @@ load ../helpers/sysbox-health
       fi
 
       # Verify that no /usr/src/linux-headers-$kernel_rel --> /usr/src/kernels/$kernel_rel
-      # softlink has been created -- shouldn't be needed in this case as sysbox-runc/mgr
-      # already bind-mount all required paths.
+      # softlink has been created -- it's not needed in this case as sysbox-runc/mgr
+      # already bind-mounts all the required paths.
       docker exec "$syscont" sh -c "stat /usr/src/linux-headers-${kernel_rel} | egrep -q \"symbolic\""
       [ "$status" -eq 1 ]
 


### PR DESCRIPTION
These new testcases verify the proper handling of kernel-header resources inside sys containers. This entails the verification of the proper bind-mounts, as well as the required softlinks, attending to the linux-distro running at the host and sys container level.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>