### PR TITLE
Extend build-infra to automate the creation of sysbox-in-docker container images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@
 	test-img test-cleanup \
 	listRuncPkgs listFsPkgs listMgrPkgs \
 	pjdfstest pjdfstest-clean \
+	sysbox-in-docker centos-8 debian-buster debian-bullseye fedora-31 fedora-32 ubuntu-bionic ubuntu-focal \
 	clean
 
 export SHELL=bash
@@ -149,7 +150,6 @@ sysbox-runc: $(LIBSECCOMP) sysbox-ipc
 
 sysbox-runc-debug: sysbox-ipc
 	@cd $(SYSRUNC_DIR) && make BUILDTAGS="$(SYSRUNC_BUILDTAGS)" sysbox-runc-debug
-
 sysbox-runc-static: sysbox-ipc
 	@cd $(SYSRUNC_DIR) && make static
 
@@ -321,6 +321,17 @@ test-mgr-local: sysbox-ipc
 	sleep 2
 	cd $(SYSMGR_DIR) && go test -timeout 3m -v $(mgrPkgs)
 
+
+##@ Sysbox-In-Docker targets
+
+sysbox-in-docker: ## Build sysbox-in-docker sandbox image
+sysbox-in-docker: sysbox
+	@cp sysbox-mgr/sysbox-mgr sysbox-in-docker/
+	@cp sysbox-runc/sysbox-runc sysbox-in-docker/
+	@cp sysbox-fs/sysbox-fs sysbox-in-docker/
+	$(MAKE) -C sysbox-in-docker --no-print-directory $(filter-out $@,$(MAKECMDGOALS))
+
+
 #
 # Misc targets
 #
@@ -328,6 +339,7 @@ test-mgr-local: sysbox-ipc
 # recvtty is a tool inside the sysbox-runc repo that is needed by some integration tests
 sysbox-runc-recvtty:
 	@cd $(SYSRUNC_DIR) && make recvtty
+
 
 #
 # Misc targets

--- a/sysbox-in-docker/Dockerfile.centos-8
+++ b/sysbox-in-docker/Dockerfile.centos-8
@@ -1,5 +1,5 @@
 #
-# Sysbox-In-Docker Container Dockerfile (Ubuntu-Focal image)
+# Sysbox-In-Docker Container Dockerfile (CentOS-8 image)
 #
 # This Dockerfile creates the sysbox-in-docker container image, which holds
 # all Sysbox binaries and its dependencies. The goal is to allow users to run
@@ -16,7 +16,7 @@
 #
 # * Image creation:
 #
-#   $ make sysbox-in-docker ubuntu-focal
+#   $ make sysbox-in-docker centos-8
 #
 # * Container creation:
 #
@@ -24,29 +24,25 @@
 #                -v /var/tmp/sysbox-var-lib-docker:/var/lib/docker \
 #                -v /var/tmp/sysbox-var-lib-sysbox:/var/lib/sysbox \
 #                -v /lib/modules/$(uname -r):/lib/modules/$(uname -r):ro \
-#                -v /usr/src/linux-headers-$(uname -r):/usr/src/linux-headers-$(uname -r):ro \
-#                -v /usr/src/linux-headers-$(uname -r | cut -d"-" -f 1,2):/usr/src/linux-headers-$(uname -r | cut -d"-" -f 1,2):ro \
-#                nestybox/sysbox-in-docker:ubuntu-focal
+#                -v /usr/src/kernels/$(uname -r):/usr/src/kernels/$(uname -r):ro \
+#                nestybox/sysbox-in-docker:centos-8
 #
 
-FROM ubuntu:focal
+FROM centos:8
 
-ENV DEBIAN_FRONTEND=noninteractive
+RUN dnf update -y && dnf install -y \
+    procps \
+    curl \
+    iproute \
+    jq \
+    kmod \
+    net-tools \
+    iputils \
+    ca-certificates \
+    fuse \
+    rsync \
+    redhat-lsb-core
 
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y \
-       apt-utils \
-       ca-certificates \
-       wget \
-       curl \
-       iproute2 \
-       jq \
-       fuse \
-       rsync \
-       dialog \
-       kmod \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
 # Install Docker.
 RUN curl -fsSL https://get.docker.com -o get-docker.sh
@@ -60,4 +56,3 @@ COPY sysbox /usr/local/sbin/sysbox
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
-

--- a/sysbox-in-docker/Dockerfile.debian-bullseye
+++ b/sysbox-in-docker/Dockerfile.debian-bullseye
@@ -5,9 +5,12 @@
 # all Sysbox binaries and its dependencies. The goal is to allow users to run
 # an entire Sysbox sandbox within a container.
 #
-# Notice that the image must be run as a privileged container, and a few resources
+# NOTE: Sysbox is a container runtime and thus needs host root privileges. As a
+# result, this image must be run as a privileged container, and a few resources
 # must be bind-mounted to meet Sysbox requirements as well as those of system-level
-# apps running in inner containers. See instructions below.
+# apps running in inner containers. Notice that within the privileged container,
+# inner containers launched with Docker + Sysbox will be strongly isolated from the
+# host by Sysbox (e.g., via the Linux user-namespace).
 #
 # Instructions:
 #
@@ -18,9 +21,8 @@
 # * Container creation:
 #
 # docker run -it --privileged --rm --hostname sysbox-in-docker --name sysbox-in-docker \
-#                -v /var/tmp/sysbox-test-var-lib-docker:/var/lib/docker \
-#                -v /var/tmp/sysbox-test-var-lib-sysbox:/var/lib/sysbox \
-#                -v /var/tmp/sysbox-test-scratch:/mnt/scratch \
+#                -v /var/tmp/sysbox-var-lib-docker:/var/lib/docker \
+#                -v /var/tmp/sysbox-var-lib-sysbox:/var/lib/sysbox \
 #                -v /lib/modules/$(uname -r):/lib/modules/$(uname -r):ro \
 #                -v /usr/src/linux-headers-$(uname -r):/usr/src/linux-headers-$(uname -r):ro \
 #                -v /usr/src/linux-headers-$(uname -r | cut -d"-" -f 1,2):/usr/src/linux-headers-$(uname -r | cut -d"-" -f 1,2):ro \
@@ -55,5 +57,6 @@ COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
 COPY sysbox-fs /usr/local/sbin/sysbox-fs
 COPY sysbox-runc /usr/local/sbin/sysbox-runc
 COPY sysbox /usr/local/sbin/sysbox
+COPY entrypoint.sh /entrypoint.sh
 
-CMD bash -c "/usr/local/sbin/sysbox && /bin/bash"
+ENTRYPOINT ["/entrypoint.sh"]

--- a/sysbox-in-docker/Dockerfile.debian-bullseye
+++ b/sysbox-in-docker/Dockerfile.debian-bullseye
@@ -1,0 +1,59 @@
+#
+# Sysbox-In-Docker Container Dockerfile (Debian-Bullseye image)
+#
+# This Dockerfile creates the sysbox-in-docker container image, which holds
+# all Sysbox binaries and its dependencies. The goal is to allow users to run
+# an entire Sysbox sandbox within a container.
+#
+# Notice that the image must be run as a privileged container, and a few resources
+# must be bind-mounted to meet Sysbox requirements as well as those of system-level
+# apps running in inner containers. See instructions below.
+#
+# Instructions:
+#
+# * Image creation:
+#
+#   $ make sysbox-in-docker debian-bullseye
+#
+# * Container creation:
+#
+# docker run -it --privileged --rm --hostname sysbox-in-docker --name sysbox-in-docker \
+#                -v /var/tmp/sysbox-test-var-lib-docker:/var/lib/docker \
+#                -v /var/tmp/sysbox-test-var-lib-sysbox:/var/lib/sysbox \
+#                -v /var/tmp/sysbox-test-scratch:/mnt/scratch \
+#                -v /lib/modules/$(uname -r):/lib/modules/$(uname -r):ro \
+#                -v /usr/src/linux-headers-$(uname -r):/usr/src/linux-headers-$(uname -r):ro \
+#                -v /usr/src/linux-headers-$(uname -r | cut -d"-" -f 1,2):/usr/src/linux-headers-$(uname -r | cut -d"-" -f 1,2):ro \
+#                nestybox/sysbox-in-docker:debian-bullseye
+#
+
+FROM debian:bullseye
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+   && apt-get install --no-install-recommends -y \
+       apt-utils \
+       ca-certificates \
+       wget \
+       curl \
+       iproute2 \
+       jq \
+       fuse \
+       rsync \
+       dialog \
+       kmod \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Docker.
+RUN curl -fsSL https://get.docker.com -o get-docker.sh
+RUN sh get-docker.sh
+
+# Copy Sysbox artifacts.
+COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
+COPY sysbox-fs /usr/local/sbin/sysbox-fs
+COPY sysbox-runc /usr/local/sbin/sysbox-runc
+COPY sysbox /usr/local/sbin/sysbox
+
+CMD bash -c "/usr/local/sbin/sysbox && /bin/bash"

--- a/sysbox-in-docker/Dockerfile.debian-buster
+++ b/sysbox-in-docker/Dockerfile.debian-buster
@@ -1,0 +1,59 @@
+#
+# Sysbox-In-Docker Container Dockerfile (Debian-Buster image)
+#
+# This Dockerfile creates the sysbox-in-docker container image, which holds
+# all Sysbox binaries and its dependencies. The goal is to allow users to run
+# an entire Sysbox sandbox within a container.
+#
+# Notice that the image must be run as a privileged container, and a few resources
+# must be bind-mounted to meet Sysbox requirements as well as those of system-level
+# apps running in inner containers. See instructions below.
+#
+# Instructions:
+#
+# * Image creation:
+#
+#   $ make sysbox-in-docker
+#
+# * Container creation:
+#
+# docker run -it --privileged --rm --hostname sysbox-in-docker --name sysbox-in-docker \
+#                -v /var/tmp/sysbox-test-var-lib-docker:/var/lib/docker \
+#                -v /var/tmp/sysbox-test-var-lib-sysbox:/var/lib/sysbox \
+#                -v /var/tmp/sysbox-test-scratch:/mnt/scratch \
+#                -v /lib/modules/$(uname -r):/lib/modules/$(uname -r):ro \
+#                -v /usr/src/linux-headers-$(uname -r):/usr/src/linux-headers-$(uname -r):ro \
+#                -v /usr/src/linux-headers-$(uname -r | cut -d"-" -f 1,2):/usr/src/linux-headers-$(uname -r | cut -d"-" -f 1,2):ro \
+#                nestybox/sysbox-in-docker:debian-buster
+#
+
+FROM debian:buster
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+   && apt-get install --no-install-recommends -y \
+       apt-utils \
+       ca-certificates \
+       wget \
+       curl \
+       iproute2 \
+       jq \
+       fuse \
+       rsync \
+       dialog \
+       kmod \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Docker.
+RUN curl -fsSL https://get.docker.com -o get-docker.sh
+RUN sh get-docker.sh
+
+# Copy Sysbox artifacts.
+COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
+COPY sysbox-fs /usr/local/sbin/sysbox-fs
+COPY sysbox-runc /usr/local/sbin/sysbox-runc
+COPY sysbox /usr/local/sbin/sysbox
+
+CMD bash -c "/usr/local/sbin/sysbox && /bin/bash"

--- a/sysbox-in-docker/Dockerfile.debian-buster
+++ b/sysbox-in-docker/Dockerfile.debian-buster
@@ -5,22 +5,24 @@
 # all Sysbox binaries and its dependencies. The goal is to allow users to run
 # an entire Sysbox sandbox within a container.
 #
-# Notice that the image must be run as a privileged container, and a few resources
+# NOTE: Sysbox is a container runtime and thus needs host root privileges. As a
+# result, this image must be run as a privileged container, and a few resources
 # must be bind-mounted to meet Sysbox requirements as well as those of system-level
-# apps running in inner containers. See instructions below.
+# apps running in inner containers. Notice that within the privileged container,
+# inner containers launched with Docker + Sysbox will be strongly isolated from the
+# host by Sysbox (e.g., via the Linux user-namespace).
 #
 # Instructions:
 #
 # * Image creation:
 #
-#   $ make sysbox-in-docker
+#   $ make sysbox-in-docker debian-buster
 #
 # * Container creation:
 #
 # docker run -it --privileged --rm --hostname sysbox-in-docker --name sysbox-in-docker \
-#                -v /var/tmp/sysbox-test-var-lib-docker:/var/lib/docker \
-#                -v /var/tmp/sysbox-test-var-lib-sysbox:/var/lib/sysbox \
-#                -v /var/tmp/sysbox-test-scratch:/mnt/scratch \
+#                -v /var/tmp/sysbox-var-lib-docker:/var/lib/docker \
+#                -v /var/tmp/sysbox-var-lib-sysbox:/var/lib/sysbox \
 #                -v /lib/modules/$(uname -r):/lib/modules/$(uname -r):ro \
 #                -v /usr/src/linux-headers-$(uname -r):/usr/src/linux-headers-$(uname -r):ro \
 #                -v /usr/src/linux-headers-$(uname -r | cut -d"-" -f 1,2):/usr/src/linux-headers-$(uname -r | cut -d"-" -f 1,2):ro \
@@ -55,5 +57,6 @@ COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
 COPY sysbox-fs /usr/local/sbin/sysbox-fs
 COPY sysbox-runc /usr/local/sbin/sysbox-runc
 COPY sysbox /usr/local/sbin/sysbox
+COPY entrypoint.sh /entrypoint.sh
 
-CMD bash -c "/usr/local/sbin/sysbox && /bin/bash"
+ENTRYPOINT ["/entrypoint.sh"]

--- a/sysbox-in-docker/Dockerfile.fedora-31
+++ b/sysbox-in-docker/Dockerfile.fedora-31
@@ -5,9 +5,12 @@
 # all Sysbox binaries and its dependencies. The goal is to allow users to run
 # an entire Sysbox sandbox within a container.
 #
-# Notice that the image must be run as a privileged container, and a few resources
+# NOTE: Sysbox is a container runtime and thus needs host root privileges. As a
+# result, this image must be run as a privileged container, and a few resources
 # must be bind-mounted to meet Sysbox requirements as well as those of system-level
-# apps running in inner containers. See instructions below.
+# apps running in inner containers. Notice that within the privileged container,
+# inner containers launched with Docker + Sysbox will be strongly isolated from the
+# host by Sysbox (e.g., via the Linux user-namespace).
 #
 # Instructions:
 #
@@ -18,9 +21,8 @@
 # * Container creation:
 #
 # docker run -it --privileged --rm --hostname sysbox-in-docker --name sysbox-in-docker \
-#                -v /var/tmp/sysbox-test-var-lib-docker:/var/lib/docker \
-#                -v /var/tmp/sysbox-test-var-lib-sysbox:/var/lib/sysbox \
-#                -v /var/tmp/sysbox-test-scratch:/mnt/scratch \
+#                -v /var/tmp/sysbox-var-lib-docker:/var/lib/docker \
+#                -v /var/tmp/sysbox-var-lib-sysbox:/var/lib/sysbox \
 #                -v /lib/modules/$(uname -r):/lib/modules/$(uname -r):ro \
 #                -v /usr/src/kernels/$(uname -r):/usr/src/kernels/$(uname -r):ro \
 #                nestybox/sysbox-in-docker:fedora-31
@@ -51,5 +53,6 @@ COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
 COPY sysbox-fs /usr/local/sbin/sysbox-fs
 COPY sysbox-runc /usr/local/sbin/sysbox-runc
 COPY sysbox /usr/local/sbin/sysbox
+COPY entrypoint.sh /entrypoint.sh
 
-CMD bash -c "/usr/local/sbin/sysbox && /bin/bash"
+ENTRYPOINT ["/entrypoint.sh"]

--- a/sysbox-in-docker/Dockerfile.fedora-31
+++ b/sysbox-in-docker/Dockerfile.fedora-31
@@ -1,0 +1,55 @@
+#
+# Sysbox-In-Docker Container Dockerfile (Fedora-31 image)
+#
+# This Dockerfile creates the sysbox-in-docker container image, which holds
+# all Sysbox binaries and its dependencies. The goal is to allow users to run
+# an entire Sysbox sandbox within a container.
+#
+# Notice that the image must be run as a privileged container, and a few resources
+# must be bind-mounted to meet Sysbox requirements as well as those of system-level
+# apps running in inner containers. See instructions below.
+#
+# Instructions:
+#
+# * Image creation:
+#
+#   $ make sysbox-in-docker fedora-31
+#
+# * Container creation:
+#
+# docker run -it --privileged --rm --hostname sysbox-in-docker --name sysbox-in-docker \
+#                -v /var/tmp/sysbox-test-var-lib-docker:/var/lib/docker \
+#                -v /var/tmp/sysbox-test-var-lib-sysbox:/var/lib/sysbox \
+#                -v /var/tmp/sysbox-test-scratch:/mnt/scratch \
+#                -v /lib/modules/$(uname -r):/lib/modules/$(uname -r):ro \
+#                -v /usr/src/kernels/$(uname -r):/usr/src/kernels/$(uname -r):ro \
+#                nestybox/sysbox-in-docker:fedora-31
+#
+
+FROM fedora:31
+
+RUN dnf update -y && dnf install -y \
+    procps \
+    curl \
+    iproute \
+    jq \
+    kmod \
+    net-tools \
+    iputils \
+    ca-certificates \
+    fuse \
+    rsync \
+    redhat-lsb-core
+
+
+# Install Docker.
+RUN curl -fsSL https://get.docker.com -o get-docker.sh
+RUN sh get-docker.sh
+
+# Copy Sysbox artifacts.
+COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
+COPY sysbox-fs /usr/local/sbin/sysbox-fs
+COPY sysbox-runc /usr/local/sbin/sysbox-runc
+COPY sysbox /usr/local/sbin/sysbox
+
+CMD bash -c "/usr/local/sbin/sysbox && /bin/bash"

--- a/sysbox-in-docker/Dockerfile.fedora-32
+++ b/sysbox-in-docker/Dockerfile.fedora-32
@@ -5,10 +5,13 @@
 # all Sysbox binaries and its dependencies. The goal is to allow users to run
 # an entire Sysbox sandbox within a container.
 #
-# Notice that the image must be run as a privileged container, and a few resources
+# NOTE: Sysbox is a container runtime and thus needs host root privileges. As a
+# result, this image must be run as a privileged container, and a few resources
 # must be bind-mounted to meet Sysbox requirements as well as those of system-level
-# apps running in inner containers. See instructions below.
-#
+# apps running in inner containers. Notice that within the privileged container,
+# inner containers launched with Docker + Sysbox will be strongly isolated from the
+# host by Sysbox (e.g., via the Linux user-namespace).
+
 # Instructions:
 #
 # * Image creation:
@@ -18,9 +21,8 @@
 # * Container creation:
 #
 # docker run -it --privileged --rm --hostname sysbox-in-docker --name sysbox-in-docker \
-#                -v /var/tmp/sysbox-test-var-lib-docker:/var/lib/docker \
-#                -v /var/tmp/sysbox-test-var-lib-sysbox:/var/lib/sysbox \
-#                -v /var/tmp/sysbox-test-scratch:/mnt/scratch \
+#                -v /var/tmp/sysbox-var-lib-docker:/var/lib/docker \
+#                -v /var/tmp/sysbox-var-lib-sysbox:/var/lib/sysbox \
 #                -v /lib/modules/$(uname -r):/lib/modules/$(uname -r):ro \
 #                -v /usr/src/kernels/$(uname -r):/usr/src/kernels/$(uname -r):ro \
 #                nestybox/sysbox-in-docker:fedora-32
@@ -51,5 +53,6 @@ COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
 COPY sysbox-fs /usr/local/sbin/sysbox-fs
 COPY sysbox-runc /usr/local/sbin/sysbox-runc
 COPY sysbox /usr/local/sbin/sysbox
+COPY entrypoint.sh /entrypoint.sh
 
-CMD bash -c "/usr/local/sbin/sysbox && /bin/bash"
+ENTRYPOINT ["/entrypoint.sh"]

--- a/sysbox-in-docker/Dockerfile.fedora-32
+++ b/sysbox-in-docker/Dockerfile.fedora-32
@@ -1,0 +1,55 @@
+#
+# Sysbox-In-Docker Container Dockerfile (Fedora-32 image)
+#
+# This Dockerfile creates the sysbox-in-docker container image, which holds
+# all Sysbox binaries and its dependencies. The goal is to allow users to run
+# an entire Sysbox sandbox within a container.
+#
+# Notice that the image must be run as a privileged container, and a few resources
+# must be bind-mounted to meet Sysbox requirements as well as those of system-level
+# apps running in inner containers. See instructions below.
+#
+# Instructions:
+#
+# * Image creation:
+#
+#   $ make sysbox-in-docker fedora-32
+#
+# * Container creation:
+#
+# docker run -it --privileged --rm --hostname sysbox-in-docker --name sysbox-in-docker \
+#                -v /var/tmp/sysbox-test-var-lib-docker:/var/lib/docker \
+#                -v /var/tmp/sysbox-test-var-lib-sysbox:/var/lib/sysbox \
+#                -v /var/tmp/sysbox-test-scratch:/mnt/scratch \
+#                -v /lib/modules/$(uname -r):/lib/modules/$(uname -r):ro \
+#                -v /usr/src/kernels/$(uname -r):/usr/src/kernels/$(uname -r):ro \
+#                nestybox/sysbox-in-docker:fedora-32
+#
+
+FROM fedora:32
+
+RUN dnf update -y && dnf install -y \
+    procps \
+    curl \
+    iproute \
+    jq \
+    kmod \
+    net-tools \
+    iputils \
+    ca-certificates \
+    fuse \
+    rsync \
+    redhat-lsb-core
+
+
+# Install Docker.
+RUN curl -fsSL https://get.docker.com -o get-docker.sh
+RUN sh get-docker.sh
+
+# Copy Sysbox artifacts.
+COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
+COPY sysbox-fs /usr/local/sbin/sysbox-fs
+COPY sysbox-runc /usr/local/sbin/sysbox-runc
+COPY sysbox /usr/local/sbin/sysbox
+
+CMD bash -c "/usr/local/sbin/sysbox && /bin/bash"

--- a/sysbox-in-docker/Dockerfile.ubuntu-bionic
+++ b/sysbox-in-docker/Dockerfile.ubuntu-bionic
@@ -1,0 +1,59 @@
+#
+# Sysbox-In-Docker Container Dockerfile (Ubuntu-Bionic image)
+#
+# This Dockerfile creates the sysbox-in-docker container image, which holds
+# all Sysbox binaries and its dependencies. The goal is to allow users to run
+# an entire Sysbox sandbox within a container.
+#
+# Notice that the image must be run as a privileged container, and a few resources
+# must be bind-mounted to meet Sysbox requirements as well as those of system-level
+# apps running in inner containers. See instructions below.
+#
+# Instructions:
+#
+# * Image creation:
+#
+#   $ make sysbox-in-docker ubuntu-bionic
+#
+# * Container creation:
+#
+# docker run -it --privileged --rm --hostname sysbox-in-docker --name sysbox-in-docker \
+#                -v /var/tmp/sysbox-test-var-lib-docker:/var/lib/docker \
+#                -v /var/tmp/sysbox-test-var-lib-sysbox:/var/lib/sysbox \
+#                -v /var/tmp/sysbox-test-scratch:/mnt/scratch \
+#                -v /lib/modules/$(uname -r):/lib/modules/$(uname -r):ro \
+#                -v /usr/src/linux-headers-$(uname -r):/usr/src/linux-headers-$(uname -r):ro \
+#                -v /usr/src/linux-headers-$(uname -r | cut -d"-" -f 1,2):/usr/src/linux-headers-$(uname -r | cut -d"-" -f 1,2):ro \
+#                nestybox/sysbox-in-docker:ubuntu-bionic
+#
+
+FROM ubuntu:bionic
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+       apt-utils \
+       ca-certificates \
+       wget \
+       curl \
+       iproute2 \
+       jq \
+       fuse \
+       rsync \
+       dialog \
+       kmod \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Docker.
+RUN curl -fsSL https://get.docker.com -o get-docker.sh
+RUN sh get-docker.sh
+
+# Copy Sysbox artifacts.
+COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
+COPY sysbox-fs /usr/local/sbin/sysbox-fs
+COPY sysbox-runc /usr/local/sbin/sysbox-runc
+COPY sysbox /usr/local/sbin/sysbox
+
+CMD bash -c "/usr/local/sbin/sysbox && /bin/bash"

--- a/sysbox-in-docker/Dockerfile.ubuntu-bionic
+++ b/sysbox-in-docker/Dockerfile.ubuntu-bionic
@@ -5,9 +5,12 @@
 # all Sysbox binaries and its dependencies. The goal is to allow users to run
 # an entire Sysbox sandbox within a container.
 #
-# Notice that the image must be run as a privileged container, and a few resources
+# NOTE: Sysbox is a container runtime and thus needs host root privileges. As a
+# result, this image must be run as a privileged container, and a few resources
 # must be bind-mounted to meet Sysbox requirements as well as those of system-level
-# apps running in inner containers. See instructions below.
+# apps running in inner containers. Notice that within the privileged container,
+# inner containers launched with Docker + Sysbox will be strongly isolated from the
+# host by Sysbox (e.g., via the Linux user-namespace).
 #
 # Instructions:
 #
@@ -18,9 +21,8 @@
 # * Container creation:
 #
 # docker run -it --privileged --rm --hostname sysbox-in-docker --name sysbox-in-docker \
-#                -v /var/tmp/sysbox-test-var-lib-docker:/var/lib/docker \
-#                -v /var/tmp/sysbox-test-var-lib-sysbox:/var/lib/sysbox \
-#                -v /var/tmp/sysbox-test-scratch:/mnt/scratch \
+#                -v /var/tmp/sysbox-var-lib-docker:/var/lib/docker \
+#                -v /var/tmp/sysbox-var-lib-sysbox:/var/lib/sysbox \
 #                -v /lib/modules/$(uname -r):/lib/modules/$(uname -r):ro \
 #                -v /usr/src/linux-headers-$(uname -r):/usr/src/linux-headers-$(uname -r):ro \
 #                -v /usr/src/linux-headers-$(uname -r | cut -d"-" -f 1,2):/usr/src/linux-headers-$(uname -r | cut -d"-" -f 1,2):ro \
@@ -55,5 +57,6 @@ COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
 COPY sysbox-fs /usr/local/sbin/sysbox-fs
 COPY sysbox-runc /usr/local/sbin/sysbox-runc
 COPY sysbox /usr/local/sbin/sysbox
+COPY entrypoint.sh /entrypoint.sh
 
-CMD bash -c "/usr/local/sbin/sysbox && /bin/bash"
+ENTRYPOINT ["/entrypoint.sh"]

--- a/sysbox-in-docker/Dockerfile.ubuntu-focal
+++ b/sysbox-in-docker/Dockerfile.ubuntu-focal
@@ -1,0 +1,59 @@
+#
+# Sysbox-In-Docker Container Dockerfile (Ubuntu-Focal image)
+#
+# This Dockerfile creates the sysbox-in-docker container image, which holds
+# all Sysbox binaries and its dependencies. The goal is to allow users to run
+# an entire Sysbox sandbox within a container.
+#
+# Notice that the image must be run as a privileged container, and a few resources
+# must be bind-mounted to meet Sysbox requirements as well as those of system-level
+# apps running in inner containers. See instructions below.
+#
+# Instructions:
+#
+# * Image creation:
+#
+#   $ make sysbox-in-docker ubuntu-focal
+#
+# * Container creation:
+#
+# docker run -it --privileged --rm --hostname sysbox-in-docker --name sysbox-in-docker \
+#                -v /var/tmp/sysbox-test-var-lib-docker:/var/lib/docker \
+#                -v /var/tmp/sysbox-test-var-lib-sysbox:/var/lib/sysbox \
+#                -v /var/tmp/sysbox-test-scratch:/mnt/scratch \
+#                -v /lib/modules/$(uname -r):/lib/modules/$(uname -r):ro \
+#                -v /usr/src/linux-headers-$(uname -r):/usr/src/linux-headers-$(uname -r):ro \
+#                -v /usr/src/linux-headers-$(uname -r | cut -d"-" -f 1,2):/usr/src/linux-headers-$(uname -r | cut -d"-" -f 1,2):ro \
+#                nestybox/sysbox-in-docker:ubuntu-focal
+#
+
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+       apt-utils \
+       ca-certificates \
+       wget \
+       curl \
+       iproute2 \
+       jq \
+       fuse \
+       rsync \
+       dialog \
+       kmod \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Docker.
+RUN curl -fsSL https://get.docker.com -o get-docker.sh
+RUN sh get-docker.sh
+
+# Copy Sysbox artifacts.
+COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
+COPY sysbox-fs /usr/local/sbin/sysbox-fs
+COPY sysbox-runc /usr/local/sbin/sysbox-runc
+COPY sysbox /usr/local/sbin/sysbox
+
+CMD bash -c "/usr/local/sbin/sysbox && /bin/bash"

--- a/sysbox-in-docker/Makefile
+++ b/sysbox-in-docker/Makefile
@@ -1,0 +1,90 @@
+#
+# Sysbox-in-docker Makefile.
+#
+# The targets in this Makefile offer a simple approach to build a docker-image
+# to run a containerized Sysbox environment.
+#
+
+
+SHELL:=/bin/bash
+SIND_IMAGE := nestybox/sysbox-in-docker
+
+
+.DEFAULT := help
+
+.PHONY: help            \
+	centos-8        \
+	debian-buster   \
+	debian-bullseye \
+	fedora-31       \
+	fedora-32       \
+	ubuntu-bionic   \
+	ubuntu-focal
+
+
+.DEFAULT := help
+
+help: ## Show supported docker images
+	@awk 'BEGIN {FS = ":.*##"; printf "\n\033[1mUsage:\n  \
+	make sysbox-in-docker \033[36m<distro-release>\033[0m\n\n"} \
+	/^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 } /^##@/ \
+	{ printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+
+LAUNCH_INSTRUCTION := docker run -it --privileged --rm --hostname sysbox-in-docker --name sysbox-in-docker \
+                -v /var/tmp/sysbox-test-var-lib-docker:/var/lib/docker \
+                -v /var/tmp/sysbox-test-var-lib-sysbox:/var/lib/sysbox \
+                -v /var/tmp/sysbox-test-scratch:/mnt/scratch \
+                -v /lib/modules/$(uname -r):/lib/modules/$(uname -r):ro \
+		$(KERNEL_HEADERS_MOUNTS)
+
+
+centos-8: ## Build CentOS-8 docker image
+	@printf "\n** Building $@ sysbox-in-docker image **\n\n"
+	@docker build -t $(SIND_IMAGE):$@ -f Dockerfile.$@ .
+	@echo $(LAUNCH_INSTRUCTION)
+	@printf "\n*** Launch container with the following instruction ***\n\n"
+	@printf "$(LAUNCH_INSTRUCTION) "
+	@printf "$(SIND_IMAGE):$@\n\n"
+
+debian-buster: ## Build Debian-Buster docker image
+	@printf "\n** Building $@ sysbox-in-docker image **\n\n"
+	@docker build -t $(SIND_IMAGE):$@ -f Dockerfile.$@ .
+	@printf "\n*** Launch container with the following instruction ***\n\n"
+	@printf "$(LAUNCH_INSTRUCTION) "
+	@printf "$(SIND_IMAGE):$@\n\n"
+
+debian-bullseye: ## Build Debian-Bullseye docker image
+	@printf "\n** Building $@ sysbox-in-docker image **\n\n"
+	@docker build -t $(SIND_IMAGE):$@ -f Dockerfile.$@ .
+	@printf "\n*** Launch container with the following instruction ***\n\n"
+	@printf "$(LAUNCH_INSTRUCTION) "
+	@printf "$(SIND_IMAGE):$@\n\n"
+
+fedora-31: ## Build Fedora-31 docker image
+	@printf "\n** Building $@ sysbox-in-docker image **\n\n"
+	@docker build -t $(SIND_IMAGE):$@ -f Dockerfile.$@ .
+	@printf "\n*** Launch container with the following instruction ***\n\n"
+	@printf "$(LAUNCH_INSTRUCTION) "
+	@printf "$(SIND_IMAGE):$@\n\n"
+
+fedora-32: ## Build Fedora-32 docker image
+	@printf "\n** Building $@ sysbox-in-docker image **\n\n"
+	@docker build -t $(SIND_IMAGE):$@ -f Dockerfile.$@ .
+	@printf "\n*** Launch container with the following instruction ***\n\n"
+	@printf "$(LAUNCH_INSTRUCTION) "
+	@printf "$(SIND_IMAGE):$@\n\n"
+
+ubuntu-bionic: ## Build Ubuntu-Bionic docker image
+	@printf "\n** Building $@ sysbox-in-docker image **\n\n"
+	@docker build -t $(SIND_IMAGE):$@ -f Dockerfile.$@ .
+	@printf "\n*** Launch container with the following instruction ***\n\n"
+	@printf "$(LAUNCH_INSTRUCTION) "
+	@printf "$(SIND_IMAGE):$@\n\n"
+
+ubuntu-focal: ## Build Ubuntu-Focal docker image
+	@printf "\n** Building $@ sysbox-in-docker image **\n\n"
+	@docker build -t $(SIND_IMAGE):$@ -f Dockerfile.$@ .
+	@printf "\n*** Launch container with the following instruction ***\n\n"
+	@printf "$(LAUNCH_INSTRUCTION) "
+	@printf "$(SIND_IMAGE):$@\n\n"

--- a/sysbox-in-docker/Makefile
+++ b/sysbox-in-docker/Makefile
@@ -32,9 +32,8 @@ help: ## Show supported docker images
 
 
 LAUNCH_INSTRUCTION := docker run -it --privileged --rm --hostname sysbox-in-docker --name sysbox-in-docker \
-                -v /var/tmp/sysbox-test-var-lib-docker:/var/lib/docker \
-                -v /var/tmp/sysbox-test-var-lib-sysbox:/var/lib/sysbox \
-                -v /var/tmp/sysbox-test-scratch:/mnt/scratch \
+                -v /var/tmp/sysbox-var-lib-docker:/var/lib/docker \
+                -v /var/tmp/sysbox-var-lib-sysbox:/var/lib/sysbox \
                 -v /lib/modules/$(uname -r):/lib/modules/$(uname -r):ro \
 		$(KERNEL_HEADERS_MOUNTS)
 

--- a/sysbox-in-docker/entrypoint.sh
+++ b/sysbox-in-docker/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+/usr/local/sbin/sysbox
+
+# Sleep for good if no command is passed to the container; otherwise run explicit
+# command in the foreground. In either case let this instruction become container's
+# init.
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    exec sleep infinity
+else
+    exec "$@"
+fi

--- a/sysbox-in-docker/sysbox
+++ b/sysbox-in-docker/sysbox
@@ -1,0 +1,345 @@
+#!/bin/bash -e
+
+#
+# Launch Sysbox (requires root privileges)
+#
+# Note: normally Sysbox is installed via a distro-specific package
+# which sets up the Sysbox systemd units. This script is meant as a
+# quick alternative to the installer to help launch Sysbox manually
+# (e.g. for development & testing).
+#
+# Usage: ./sysbox [testing-on]
+#
+# Note: "testing-on" attribute is useful to launch Sysbox inside a privileged
+# container. In this context Sysbox may be unable to reach certain procfs
+# nodes, due to kernel not exposing them in non-init namespaces. This flag
+# alerts Sysbox of the need to obviate these potential errors when running
+# in testing mode.
+#
+
+# Max number of user-namespaces to configure in distros supporting this knob.
+sysbox_max_user_ns=10000
+
+# Default mtu value associated to container's egress-interface.
+default_mtu=1500
+
+# UID-shifting module
+shiftfs_module="shiftfs"
+
+# Dockerd default configuration dir/file.
+dockerCfgDir="/etc/docker"
+dockerCfgFile="${dockerCfgDir}/daemon.json"
+
+# Temp file for jq write operations.
+tmpfile=$(mktemp /tmp/init-scr.XXXXXX)
+trap 'rm -f "${tmpfile}"' EXIT
+
+
+# Retry a command $1 times until it succeeds. Wait $2 seconds between retries.
+# (copied from runc/tests/integration/helpers.bash)
+function retry() {
+  local attempts=$1
+  shift
+  local delay=$1
+  shift
+  local i
+
+  for ((i = 0; i < attempts; i++)); do
+    $@
+    if [ "$?" -eq 0 ]; then
+	return 0
+    fi
+    sleep $delay
+  done
+
+  echo "Command \"$@\" failed $attempts times. Output: $?"
+  false
+}
+
+# Ensure that kernel-modules expected by system-level apps (running within sys
+# containers) are properly loaded.
+function load_required_modules() {
+
+  # Sysbox requires 'configfs' module to ensure proper operation of containerized
+  # apps requiring access to kernel's config file (e.g. kubeadm).
+  if ! modprobe configfs &> /dev/null; then
+      echo "Could not load configfs kernel module. Exiting ..."
+      return 1
+  fi
+
+  return 0
+}
+
+# Returns linux distro running in the system.
+function get_host_distro() {
+
+  local distro=$(cat /etc/os-release | awk -F"=" '/^ID=/ {print $2}' | tr -d '"')
+
+  echo $distro
+}
+
+# Ensures unprivileged user-ns's are allowed.
+function userns_setup() {
+
+  local distro=$1
+
+  if [[ "${distro}" == "ubuntu" ]] ||
+     [[ "${distro}" == "debian" ]]; then
+      echo "1" > /proc/sys/kernel/unprivileged_userns_clone
+
+  elif [[ "${distro}" == "centos" ]] ||
+       [[ "${distro}" == "fedora" ]]; then
+
+      # Setting user-ns max value.
+      max_user_ns=$(</proc/sys/user/max_user_namespaces)
+      if [[ $max_user_ns =~ ^[0-9]+$ ]] && [[ $max_user_ns -lt $sysbox_max_user_ns ]]; then
+	  echo $sysbox_max_user_ns > /proc/sys/user/max_user_namespaces
+      fi
+
+  else
+      echo "Unsupported Linux distribution: $distro. Sysbox may not opperate as expected."
+  fi
+}
+
+# Identifies kernel-header's expected path based on distro.
+function kernel_header_path() {
+
+  local distro=$1
+  local path
+
+  if [[ "${distro}" == "centos" ]] ||
+     [[ "${distro}" == "fedora" ]] ||
+     [[ "${distro}" == "redhat" ]]; then
+      path="/usr/src/kernels/$(uname -r)"
+  else
+      path="/usr/src/linux-headers-$(uname -r)"
+  fi
+
+  echo "$path"
+}
+
+# Verifies that a kernel configuration file is found, and if that's not the case,
+# copy it from the original "/boot" folder. Notice that this may not work when
+# running sysbox within a test-priv container, as "/boot" folder may not be around;
+# in those cases initialization will proceed as normal and a log will be dumped to
+# alert the user.
+function kernel_config_setup() {
+
+  local distro=$1
+
+  local kernel_path=$(kernel_header_path $distro)
+
+  if [[ ! -f "${kernel_path}"/.config ]]; then
+      # Attempt to find kernel config in /boot path.
+      if [[ -d /boot ]] && [[ -f /boot/config-$(uname -r) ]]; then
+	  cp /boot/config-$(uname -r) "${kernel_path}"/.config
+	  return
+      fi
+
+      echo -e "\nUnable to find a kernel config file. This may affect some system" \
+	   "level apps running within sys-containers. As a solution, identify your" \
+	   "kernel config file in the host (typically: \"/boot/config-$(uname -r)\")" \
+	   "and copy it into your distro's expected kernel-headers path" \
+	   "(usually: \"$(kernel_header_path $distro)\").\n"
+  fi
+}
+
+#
+# Obtain the MTU value to be configured for the docker interface within the test
+# container. This value shall be the lowest among these ...
+#
+#  * The 'physical' default-gateway interface at host level (L0).
+#  * The 'logical' default-gateway interface connecting the test-container (L1) with the host.
+#  * The 'default' mtu value (1500 bytes) supported by most NICs.
+#
+function docker_iface_mtu() {
+
+  local egress_iface
+  local l0_egress_mtu
+  local l1_egress_mtu
+
+  # Identify default egress iface.
+  local egress_iface=$(ip route show | awk '/default via/ {print $5}')
+  if [ -z "${egress_iface}" ]; then
+	  return
+  fi
+
+  # Obtain mtu value associated to the test-container's egress interface.
+  egress_mtu=$(ip link show ${egress_iface} | awk '/mtu / {print $5}')
+  if [ ! -z "${egress_mtu}" ] &&
+     [ "${egress_mtu}" -lt "${default_mtu}" ]; then
+	  l1_egress_mtu=${egress_mtu}
+  else
+	  l1_egress_mtu=${default_mtu}
+  fi
+
+  # Pull L0 egress-mtu value passed from Sysbox's makefile.
+  l0_egress_mtu=${PHY_EGRESS_IFACE_MTU}
+
+  if [ "${l0_egress_mtu}" -lt "${l1_egress_mtu}" ]; then
+	  echo ${l0_egress_mtu}
+  else
+	  echo ${l1_egress_mtu}
+  fi
+}
+
+# Create docker configuration.
+function docker_setup() {
+
+  # Configure dockerd
+  mkdir -p "${dockerCfgDir}"
+
+  # If shiftfs module is not present then consider configuring docker in userns
+  # mode.
+  if ! modprobe "${shiftfs_module}" &> /dev/null ; then
+	  cat <<EOF > "${dockerCfgFile}"
+{
+    "debug": false,
+    "userns-remap": "sysbox",
+    "runtimes": {
+        "sysbox-runc": {
+            "path": "/usr/local/sbin/sysbox-runc"
+        }
+    },
+    "bip": "172.24.0.1/16",
+    "default-address-pools": [
+        {
+            "base": "172.31.0.0/16",
+            "size": 24
+        }
+    ]
+}
+EOF
+  else
+	  cat <<EOF > "${dockerCfgFile}"
+{
+    "debug": false,
+    "userns-remap": "",
+    "runtimes": {
+        "sysbox-runc": {
+            "path": "/usr/local/sbin/sysbox-runc",
+            "runtimeArgs": [
+                "--no-kernel-check"
+            ]
+        }
+    },
+    "bip": "172.24.0.1/16",
+    "default-address-pools": [
+        {
+            "base": "172.31.0.0/16",
+            "size": 24
+        }
+    ]
+}
+EOF
+  fi
+
+  # Adjust docker's interface mtu configuration. This is required to avoid forwarding issues
+  # in containers seating behind an egress-interface with lower-than-default mtu.
+  # egress_mtu=$(docker_iface_mtu)
+  # if [ ! -z "${egress_mtu}" ] && [ "${egress_mtu}" -ne "${default_mtu}" ]; then
+	#   jq --arg mtu "${egress_mtu}" --indent 4 '. + {"mtu": $mtu|tonumber}' "${dockerCfgFile}" \
+	#      > ${tmpfile} && cp ${tmpfile} "${dockerCfgFile}"
+  # fi
+}
+
+# Increases system-level resources to satisfy Sysbox requirements.
+function maxs_setup() {
+
+  # Increase default inotify resources to meet sys container's demands.
+  sysctl -w fs.inotify.max_queued_events=1048576 &> /dev/null
+  sysctl -w fs.inotify.max_user_watches=1048576 &> /dev/null
+  sysctl -w fs.inotify.max_user_instances=1048576 &> /dev/null
+
+  # Increase default keyring resources to meet sys container demands.
+  # For a k8s cluster:
+  # keys = 35 + (workers * 23) + (2 * pods)
+  # maxbytes = 20 bytes * maxkeys
+  sysctl -w kernel.keys.maxkeys=20000 &> /dev/null
+  sysctl -w kernel.keys.maxbytes=$((20*20000)) &> /dev/null
+}
+
+# Completes Sysbox's setup process.
+function sysbox_setup() {
+
+  local distro=$(get_host_distro)
+
+  if ! load_required_modules; then
+      exit 1
+  fi
+
+  userns_setup $distro
+  kernel_config_setup $distro
+  docker_setup
+  maxs_setup
+}
+
+# Stop all Sysbox components.
+function sysbox_stop() {
+
+  sysmgr_pids=$(pidof sysbox-mgr) || true
+  sysfs_pids=$(pidof sysbox-fs) || true
+
+  for pid in $sysmgr_pids; do
+    kill $pid
+  done
+
+  for pid in $sysfs_pids; do
+    kill $pid
+  done
+}
+
+# Start all Sysbox components.
+function sysbox_start() {
+
+  local testing_mode=$1
+
+  # Start sysbox-mgr.
+  /usr/local/sbin/sysbox-mgr --log /dev/stdout > /var/log/sysbox-mgr.log 2>&1 &
+  RES=$(retry 10 1 grep -q Ready /var/log/sysbox-mgr.log)
+  if [ $? -ne 0 ]; then
+    printf "\nsysbox-mgr failed to start. Here is the log file:\n"
+    cat /var/log/sysbox-mgr.log
+    exit 1
+  fi
+
+  # Start sysbox-fs.
+  mkdir -p /var/lib/sysboxfs
+
+  if [[ $testing_mode == "testing-on" ]]; then
+      /usr/local/sbin/sysbox-fs --ignore-handler-errors --log /dev/stdout > /var/log/sysbox-fs.log 2>&1 &
+  else
+      /usr/local/sbin/sysbox-fs --log /dev/stdout > /var/log/sysbox-fs.log 2>&1 &
+  fi
+  RES=$(retry 10 1 grep -q Initiating /var/log/sysbox-fs.log)
+  if [ $? -ne 0 ]; then
+    printf "\nsysbox-fs failed to start. Here is the log file:\n"
+    cat /var/log/sysbox-fs.log
+    exit 1
+  fi
+}
+
+# Start Docker.
+function docker_start() {
+
+  if ! pidof dockerd; then
+    dockerd > /var/log/dockerd.log 2>&1 &
+    RES=$(retry 10 1 docker ps > /dev/null 2>&1)
+    if [ $? -ne 0 ]; then
+      printf "\dockerd failed to start.\n"
+      exit 1
+    fi
+  fi
+}
+
+
+function main() {
+
+  sysbox_stop
+  sysbox_setup
+  docker_start
+  sysbox_start "$@"
+}
+
+main "$@"
+

--- a/sysbox-in-docker/sysbox
+++ b/sysbox-in-docker/sysbox
@@ -332,7 +332,6 @@ function docker_start() {
   fi
 }
 
-
 function main() {
 
   sysbox_stop
@@ -342,4 +341,3 @@ function main() {
 }
 
 main "$@"
-


### PR DESCRIPTION
Our goal here is to automate the creation of docker images that contain an entire Sysbox sandbox. By doing this, users can easily interact with Sysbox runtime without needing to install it in their host machines.

```
$ make sysbox-in-docker

Usage:
  make sysbox-in-docker <distro-release>

  help                       Show supported docker images
  centos-8                   Build CentOS-8 docker image
  debian-buster              Build Debian-Buster docker image
  debian-bullseye            Build Debian-Bullseye docker image
  fedora-31                  Build Fedora-31 docker image
  fedora-32                  Build Fedora-32 docker image
  ubuntu-bionic              Build Ubuntu-Bionic docker image
  ubuntu-focal               Build Ubuntu-Focal docker image
```

Signed-off-by: Rodny Molina <rmolina@nestybox.com>