### PR TITLE
Sysbox build/test container: use the old definition for SECCOMP_NOTIF_ID_VALID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,6 @@ DOCKER_SYSBOX_BLD := docker run --privileged --rm                     \
 			-v $(CURDIR):$(PROJECT)                       \
 			-v $(GOPATH)/pkg/mod:/go/pkg/mod              \
 			-v /lib/modules/$(KERNEL_REL):/lib/modules/$(KERNEL_REL):ro \
-			-v /usr/include/linux/seccomp.h:/usr/include/linux/seccomp.h:ro \
 			$(KERNEL_HEADERS_MOUNTS) \
 			$(TEST_IMAGE)
 
@@ -213,7 +212,6 @@ DOCKER_RUN := docker run -it --privileged --rm                        \
 			-v $(TEST_VOL3):/mnt/scratch                  \
 			-v $(GOPATH)/pkg/mod:/go/pkg/mod              \
 			-v /lib/modules/$(KERNEL_REL):/lib/modules/$(KERNEL_REL):ro \
-			-v /usr/include/linux/seccomp.h:/usr/include/linux/seccomp.h:ro \
 			$(KERNEL_HEADERS_MOUNTS) \
 			$(TEST_IMAGE)
 

--- a/tests/Dockerfile.centos-8
+++ b/tests/Dockerfile.centos-8
@@ -125,6 +125,18 @@ RUN dnf update -y \
 ADD https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker \
     /etc/bash_completion.d/docker.sh
 
+# Use the old definition for SECCOMP_NOTIF_ID_VALID in /usr/include/linux/seccomp.h
+#
+# This is needed because the definition changed in the mainline kernel
+# on 06/2020 (from SECCOMP_IOR -> SECCOMP_IOW), and some distros we
+# support have picked it up in their latest releases / kernels
+# updates. The kernel change was backward compatible, so by using the
+# old definition, we are guaranteed it will work on kernels before and
+# after the change. On the other hand, if we were to use the new
+# definition, seccomp notify would fail when sysbox runs in old
+# kernels.
+RUN sed -i 's/^#define SECCOMP_IOCTL_NOTIF_ID_VALID[ \t]*SECCOMP_IOW(2, __u64)/#define SECCOMP_IOCTL_NOTIF_ID_VALID   SECCOMP_IOR(2, __u64)/g' /usr/include/linux/seccomp.h
+
 # sysbox env
 RUN useradd sysbox \
     && mkdir -p /var/lib/sysboxfs

--- a/tests/Dockerfile.debian-buster
+++ b/tests/Dockerfile.debian-buster
@@ -139,6 +139,18 @@ RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
+# Use the old definition for SECCOMP_NOTIF_ID_VALID in /usr/include/linux/seccomp.h
+#
+# This is needed because the definition changed in the mainline kernel
+# on 06/2020 (from SECCOMP_IOR -> SECCOMP_IOW), and some distros we
+# support have picked it up in their latest releases / kernels
+# updates. The kernel change was backward compatible, so by using the
+# old definition, we are guaranteed it will work on kernels before and
+# after the change. On the other hand, if we were to use the new
+# definition, seccomp notify would fail when sysbox runs in old
+# kernels.
+RUN sed -i 's/^#define SECCOMP_IOCTL_NOTIF_ID_VALID[ \t]*SECCOMP_IOW(2, __u64)/#define SECCOMP_IOCTL_NOTIF_ID_VALID   SECCOMP_IOR(2, __u64)/g' /usr/include/linux/seccomp.h
+
 # sysbox env
 RUN useradd sysbox \
     && mkdir -p /var/lib/sysboxfs

--- a/tests/Dockerfile.fedora-31
+++ b/tests/Dockerfile.fedora-31
@@ -126,6 +126,18 @@ RUN dnf update -y \
 ADD https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker \
     /etc/bash_completion.d/docker.sh
 
+# Use the old definition for SECCOMP_NOTIF_ID_VALID in /usr/include/linux/seccomp.h
+#
+# This is needed because the definition changed in the mainline kernel
+# on 06/2020 (from SECCOMP_IOR -> SECCOMP_IOW), and some distros we
+# support have picked it up in their latest releases / kernels
+# updates. The kernel change was backward compatible, so by using the
+# old definition, we are guaranteed it will work on kernels before and
+# after the change. On the other hand, if we were to use the new
+# definition, seccomp notify would fail when sysbox runs in old
+# kernels.
+RUN sed -i 's/^#define SECCOMP_IOCTL_NOTIF_ID_VALID[ \t]*SECCOMP_IOW(2, __u64)/#define SECCOMP_IOCTL_NOTIF_ID_VALID   SECCOMP_IOR(2, __u64)/g' /usr/include/linux/seccomp.h
+
 # sysbox env
 RUN useradd sysbox \
     && mkdir -p /var/lib/sysboxfs

--- a/tests/Dockerfile.ubuntu-bionic
+++ b/tests/Dockerfile.ubuntu-bionic
@@ -139,6 +139,18 @@ RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
+# Use the old definition for SECCOMP_NOTIF_ID_VALID in /usr/include/linux/seccomp.h
+#
+# This is needed because the definition changed in the mainline kernel
+# on 06/2020 (from SECCOMP_IOR -> SECCOMP_IOW), and some distros we
+# support have picked it up in their latest releases / kernels
+# updates. The kernel change was backward compatible, so by using the
+# old definition, we are guaranteed it will work on kernels before and
+# after the change. On the other hand, if we were to use the new
+# definition, seccomp notify would fail when sysbox runs in old
+# kernels.
+RUN sed -i 's/^#define SECCOMP_IOCTL_NOTIF_ID_VALID[ \t]*SECCOMP_IOW(2, __u64)/#define SECCOMP_IOCTL_NOTIF_ID_VALID   SECCOMP_IOR(2, __u64)/g' /usr/include/linux/seccomp.h
+
 # sysbox env
 RUN useradd sysbox \
     && mkdir -p /var/lib/sysboxfs

--- a/tests/Dockerfile.ubuntu-cosmic
+++ b/tests/Dockerfile.ubuntu-cosmic
@@ -125,6 +125,18 @@ RUN apt-get update && apt-get install -y \
     fuse \
     rsync
 
+# Use the old definition for SECCOMP_NOTIF_ID_VALID in /usr/include/linux/seccomp.h
+#
+# This is needed because the definition changed in the mainline kernel
+# on 06/2020 (from SECCOMP_IOR -> SECCOMP_IOW), and some distros we
+# support have picked it up in their latest releases / kernels
+# updates. The kernel change was backward compatible, so by using the
+# old definition, we are guaranteed it will work on kernels before and
+# after the change. On the other hand, if we were to use the new
+# definition, seccomp notify would fail when sysbox runs in old
+# kernels.
+RUN sed -i 's/^#define SECCOMP_IOCTL_NOTIF_ID_VALID[ \t]*SECCOMP_IOW(2, __u64)/#define SECCOMP_IOCTL_NOTIF_ID_VALID   SECCOMP_IOR(2, __u64)/g' /usr/include/linux/seccomp.h
+
 # sysbox env
 RUN useradd sysbox \
     && mkdir -p /var/lib/sysboxfs

--- a/tests/Dockerfile.ubuntu-disco
+++ b/tests/Dockerfile.ubuntu-disco
@@ -125,6 +125,18 @@ RUN apt-get update && apt-get install -y \
     fuse \
     rsync
 
+# Use the old definition for SECCOMP_NOTIF_ID_VALID in /usr/include/linux/seccomp.h
+#
+# This is needed because the definition changed in the mainline kernel
+# on 06/2020 (from SECCOMP_IOR -> SECCOMP_IOW), and some distros we
+# support have picked it up in their latest releases / kernels
+# updates. The kernel change was backward compatible, so by using the
+# old definition, we are guaranteed it will work on kernels before and
+# after the change. On the other hand, if we were to use the new
+# definition, seccomp notify would fail when sysbox runs in old
+# kernels.
+RUN sed -i 's/^#define SECCOMP_IOCTL_NOTIF_ID_VALID[ \t]*SECCOMP_IOW(2, __u64)/#define SECCOMP_IOCTL_NOTIF_ID_VALID   SECCOMP_IOR(2, __u64)/g' /usr/include/linux/seccomp.h
+
 # sysbox env
 RUN useradd sysbox \
     && mkdir -p /var/lib/sysboxfs

--- a/tests/Dockerfile.ubuntu-eoan
+++ b/tests/Dockerfile.ubuntu-eoan
@@ -139,6 +139,18 @@ RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
+# Use the old definition for SECCOMP_NOTIF_ID_VALID in /usr/include/linux/seccomp.h
+#
+# This is needed because the definition changed in the mainline kernel
+# on 06/2020 (from SECCOMP_IOR -> SECCOMP_IOW), and some distros we
+# support have picked it up in their latest releases / kernels
+# updates. The kernel change was backward compatible, so by using the
+# old definition, we are guaranteed it will work on kernels before and
+# after the change. On the other hand, if we were to use the new
+# definition, seccomp notify would fail when sysbox runs in old
+# kernels.
+RUN sed -i 's/^#define SECCOMP_IOCTL_NOTIF_ID_VALID[ \t]*SECCOMP_IOW(2, __u64)/#define SECCOMP_IOCTL_NOTIF_ID_VALID   SECCOMP_IOR(2, __u64)/g' /usr/include/linux/seccomp.h
+
 # sysbox env
 RUN useradd sysbox \
     && mkdir -p /var/lib/sysboxfs

--- a/tests/Dockerfile.ubuntu-focal
+++ b/tests/Dockerfile.ubuntu-focal
@@ -139,6 +139,18 @@ RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
+# Use the old definition for SECCOMP_NOTIF_ID_VALID in /usr/include/linux/seccomp.h
+#
+# This is needed because the definition changed in the mainline kernel
+# on 06/2020 (from SECCOMP_IOR -> SECCOMP_IOW), and some distros we
+# support have picked it up in their latest releases / kernels
+# updates. The kernel change was backward compatible, so by using the
+# old definition, we are guaranteed it will work on kernels before and
+# after the change. On the other hand, if we were to use the new
+# definition, seccomp notify would fail when sysbox runs in old
+# kernels.
+RUN sed -i 's/^#define SECCOMP_IOCTL_NOTIF_ID_VALID[ \t]*SECCOMP_IOW(2, __u64)/#define SECCOMP_IOCTL_NOTIF_ID_VALID   SECCOMP_IOR(2, __u64)/g' /usr/include/linux/seccomp.h
+
 # sysbox env
 RUN useradd sysbox \
     && mkdir -p /var/lib/sysboxfs


### PR DESCRIPTION
Recently, the definition of SECCOMP_NOTIF_ID_VALID changed in the
mainline kernel, from SECCOMP_IOR(2, __u64) to SECCOMP_IOW(2,
__u64). The change ocurred on 06/2020.

Some distros we support have picked it up in their latest releases or
kernels updates, and this change is reflected in the libc header
"/usr/include/linux/seccomp.h" of said distros. Sysbox uses that
header when building the libseccomp library.

The problem is that if Sysbox is built with the new definition for
SECCOMP_NOTIF_ID_VALID, it will not run correctly on machines
with kernels that have the old definition (i.e., the sysbox-fs log
will report seccomp time-of-check-time-of-use (TOCTOU) failures).

Fortunately the kernel change was backward compatible, so by using the
old definition for SECCOMP_NOTIF_ID_VALID when building Sysbox, we are
guaranteed it will work on kernels that have the old or new
definition.

This commit ensures that inside the Sysbox test/build containers, we
always use the old definition of SECCOMP_NOTIF_ID_VALID in
"/usr/include/linux/seccomp.h".

Signed-off-by: ctalledo <ctalledo@nestybox.com>