### PR TITLE
Minor Makefile adjustment to ease the dev/test workflow in docker-compose / swarm scenarios [skip ci]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ help:
 
 ##@ Building targets
 
-DOCKER_SYSBOX_BLD := docker run --privileged --rm                     \
+DOCKER_SYSBOX_BLD := docker run --privileged --rm --runtime=runc      \
 			--hostname sysbox-build                       \
 			--name sysbox-build                           \
 			-v $(CURDIR):$(PROJECT)                       \
@@ -207,7 +207,7 @@ uninstall: ## Uninstall all sysbox binaries (requires root privileges)
 # they are meant as development tests.
 #
 
-DOCKER_RUN := docker run -it --privileged --rm                        \
+DOCKER_RUN := docker run -it --privileged --rm --runtime=runc         \
 			--hostname sysbox-test                        \
 			--name sysbox-test                            \
 			-v $(CURDIR):$(PROJECT)                       \


### PR DESCRIPTION
This minor change simplifies the workflow when working with docker-compose and docker-swarm scenarios, where a 'runtime' feature is not either available (docker-swarm), or matured enough (docker-compose). In this environment is handy to set sysbox-runc as the default runtime, while continuing to use regular runc for building/testing sysbox.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>