### PR TITLE
Hint about cloning without GitHub SSH key [skip ci]

### DIFF
--- a/docs/developers-guide/build.md
+++ b/docs/developers-guide/build.md
@@ -43,7 +43,7 @@ outside your $GOPATH.
 
 In case of authentication error, make sure your setup is properly configured
 to allow ssh connectivity to Github. Refer to [this](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh)
-doc for details.
+doc for details. Or make git use `https` instead of `ssh` by configuring `git config --global url.https://github.com/.insteadOf git@github.com:`.
 
 ## The Sysbox Makefile
 


### PR DESCRIPTION
Thanks for sysbox! Just a small documentation hint, which might be useful especially when running sysbox builds in non-GitHub CI.