### PR TITLE
Add new debugging targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,9 +375,24 @@ test-shell: test-img
 		make sysbox-runc-recvtty && \
 		testContainerInit && /bin/bash"
 
+test-shell-debug: test-img
+	$(TEST_DIR)/scr/testContainerPre $(TEST_VOL1) $(TEST_VOL2) $(TEST_VOL3)
+	$(DOCKER_RUN_TTY) /bin/bash -c "export PHY_EGRESS_IFACE_MTU=$(EGRESS_IFACE_MTU) && \
+		make sysbox-runc-recvtty && \
+		export DEBUG_ON=true && testContainerInit && /bin/bash"
+
 test-shell-systemd: ## Get a shell in the test container that includes systemd (useful for debug)
 test-shell-systemd: test-img-systemd
 	$(eval DOCKER_ENV := -e PHY_EGRESS_IFACE_MTU=$(EGRESS_IFACE_MTU))
+	$(TEST_DIR)/scr/testContainerPre $(TEST_VOL1) $(TEST_VOL2) $(TEST_VOL3)
+	$(DOCKER_RUN_SYSTEMD)
+	docker exec $(DOCKER_ENV) sysbox-test make sysbox-runc-recvtty
+	docker exec $(DOCKER_ENV) sysbox-test testContainerInit
+	docker exec -it $(DOCKER_ENV) sysbox-test /bin/bash
+	$(DOCKER_STOP)
+
+test-shell-systemd-debug: test-img-systemd
+	$(eval DOCKER_ENV := -e PHY_EGRESS_IFACE_MTU=$(EGRESS_IFACE_MTU) -e DEBUG_ON=true)
 	$(TEST_DIR)/scr/testContainerPre $(TEST_VOL1) $(TEST_VOL2) $(TEST_VOL3)
 	$(DOCKER_RUN_SYSTEMD)
 	docker exec $(DOCKER_ENV) sysbox-test make sysbox-runc-recvtty
@@ -396,12 +411,29 @@ test-shell-installer: test-img-systemd
 	docker exec -it $(DOCKER_ENV) sysbox-test /bin/bash
 	$(DOCKER_STOP)
 
+test-shell-installer-debug: test-img-systemd
+	$(eval DOCKER_ENV := -e PHY_EGRESS_IFACE_MTU=$(EGRESS_IFACE_MTU) \
+		-e SB_INSTALLER=true -e SB_INSTALLER_PKG=$(IMAGE_FILE_PATH)/$(IMAGE_FILE_NAME) \
+		-e DEBUG_ON=true)
+	$(TEST_DIR)/scr/testContainerPre $(TEST_VOL1) $(TEST_VOL2) $(TEST_VOL3)
+	$(DOCKER_RUN_SYSTEMD)
+	docker exec $(DOCKER_ENV) sysbox-test make sysbox-runc-recvtty
+	docker exec $(DOCKER_ENV) sysbox-test testContainerInit
+	docker exec -it $(DOCKER_ENV) sysbox-test /bin/bash
+	$(DOCKER_STOP)
+
 test-shell-shiftuid: ## Get a shell in the test container with uid-shifting
 test-shell-shiftuid: test-img
 	$(TEST_DIR)/scr/testContainerPre $(TEST_VOL1) $(TEST_VOL2) $(TEST_VOL3)
 	$(DOCKER_RUN_TTY) /bin/bash -c "export PHY_EGRESS_IFACE_MTU=$(EGRESS_IFACE_MTU) && \
 		make sysbox-runc-recvtty && \
 		export SHIFT_UIDS=true && testContainerInit && /bin/bash"
+
+test-shell-shiftuid-debug: test-img
+	$(TEST_DIR)/scr/testContainerPre $(TEST_VOL1) $(TEST_VOL2) $(TEST_VOL3)
+	$(DOCKER_RUN_TTY) /bin/bash -c "export PHY_EGRESS_IFACE_MTU=$(EGRESS_IFACE_MTU) && \
+		make sysbox-runc-recvtty && \
+		export SHIFT_UIDS=true DEBUG_ON=true && testContainerInit && /bin/bash"
 
 test-shell-shiftuid-systemd: ## Get a shell in the test container that includes shiftfs & systemd (useful for debug)
 test-shell-shiftuid-systemd: test-img-systemd
@@ -413,10 +445,30 @@ test-shell-shiftuid-systemd: test-img-systemd
 	docker exec -it $(DOCKER_ENV) sysbox-test /bin/bash
 	$(DOCKER_STOP)
 
+test-shell-shiftuid-systemd: test-img-systemd
+	$(eval DOCKER_ENV := -e PHY_EGRESS_IFACE_MTU=$(EGRESS_IFACE_MTU) -e SHIFT_UIDS=true -e DEBUG_ON=true)
+	$(TEST_DIR)/scr/testContainerPre $(TEST_VOL1) $(TEST_VOL2) $(TEST_VOL3)
+	$(DOCKER_RUN_SYSTEMD)
+	docker exec $(DOCKER_ENV) sysbox-test make sysbox-runc-recvtty
+	docker exec $(DOCKER_ENV) sysbox-test testContainerInit
+	docker exec -it $(DOCKER_ENV) sysbox-test /bin/bash
+	$(DOCKER_STOP)
+
 test-shell-shiftuid-installer: ## Get a shell in the test container that includes shiftfs, systemd and the sysbox installer (useful for debug)
 test-shell-shiftuid-installer: test-img-systemd
 	$(eval DOCKER_ENV := -e PHY_EGRESS_IFACE_MTU=$(EGRESS_IFACE_MTU) -e SHIFT_UIDS=true \
 		-e SB_INSTALLER=true -e SB_INSTALLER_PKG=$(IMAGE_FILE_PATH)/$(IMAGE_FILE_NAME))
+	$(TEST_DIR)/scr/testContainerPre $(TEST_VOL1) $(TEST_VOL2) $(TEST_VOL3)
+	$(DOCKER_RUN_SYSTEMD)
+	docker exec $(DOCKER_ENV) sysbox-test make sysbox-runc-recvtty
+	docker exec $(DOCKER_ENV) sysbox-test testContainerInit
+	docker exec -it $(DOCKER_ENV) sysbox-test /bin/bash
+	$(DOCKER_STOP)
+
+test-shell-shiftuid-installer-debug: test-img-systemd
+	$(eval DOCKER_ENV := -e PHY_EGRESS_IFACE_MTU=$(EGRESS_IFACE_MTU) -e SHIFT_UIDS=true \
+		-e SB_INSTALLER=true -e SB_INSTALLER_PKG=$(IMAGE_FILE_PATH)/$(IMAGE_FILE_NAME) \
+		-e DEBUG_ON=true)
 	$(TEST_DIR)/scr/testContainerPre $(TEST_VOL1) $(TEST_VOL2) $(TEST_VOL3)
 	$(DOCKER_RUN_SYSTEMD)
 	docker exec $(DOCKER_ENV) sysbox-test make sysbox-runc-recvtty

--- a/tests/scr/testContainerInit
+++ b/tests/scr/testContainerInit
@@ -144,7 +144,7 @@ function install_sysbox_pkg() {
 	# Add the '--ignore-handler-errors' to the sysbox-fs service and restart it
 	# (need this flag inside the test container). Also, add '--log-level debug'
 	# knob to sysbox-fs/mgr if requested.
-	if [ ! -z "$DEBUG_ON" ]; then
+	if [ -n "$DEBUG_ON" ]; then
 		sed -i 's|ExecStart=/usr/local/sbin/sysbox-fs|ExecStart=/usr/local/sbin/sysbox-fs --log-level debug --ignore-handler-errors|g' \
 			/lib/systemd/system/sysbox-fs.service && \
 		sed -i 's|ExecStart=/usr/local/sbin/sysbox-mgr|ExecStart=/usr/local/sbin/sysbox-mgr --log-level debug|g' \
@@ -176,7 +176,7 @@ function build_sysbox() {
 		make clean
 	fi
 
-	if [ ! -z "${DEBUG_ON}" ]; then
+	if [ -n "${DEBUG_ON}" ]; then
 		echo "Building sysbox for debugging purposes (unstripped binaries & compiler optimizations off)..."
 		make sysbox-debug-local --no-print-directory && make install
 	else
@@ -203,7 +203,7 @@ function main() {
    # Install sysbox
 	if [[ "$SB_INSTALLER" == "true" ]]; then
 		install_sysbox_pkg
-	elif [ ! -z "$DEBUG_ON" ]; then
+	elif [ -n "$DEBUG_ON" ]; then
 		build_sysbox
 
 		echo "Starting sysbox in debug mode ..."

--- a/tests/scr/testContainerInit
+++ b/tests/scr/testContainerInit
@@ -142,11 +142,21 @@ function install_sysbox_pkg() {
 	dpkg -i ${SB_INSTALLER_PKG}
 
 	# Add the '--ignore-handler-errors' to the sysbox-fs service and restart it
-	# (need this flag inside the test container)
-	sed -i 's|ExecStart=/usr/local/sbin/sysbox-fs|ExecStart=/usr/local/sbin/sysbox-fs --ignore-handler-errors|g' \
-		 /lib/systemd/system/sysbox-fs.service && \
+	# (need this flag inside the test container). Also, add '--log-level debug'
+	# knob to sysbox-fs/mgr if requested.
+	if [ ! -z "$DEBUG_ON" ]; then
+		sed -i 's|ExecStart=/usr/local/sbin/sysbox-fs|ExecStart=/usr/local/sbin/sysbox-fs --log-level debug --ignore-handler-errors|g' \
+			/lib/systemd/system/sysbox-fs.service && \
+		sed -i 's|ExecStart=/usr/local/sbin/sysbox-mgr|ExecStart=/usr/local/sbin/sysbox-mgr --log-level debug|g' \
+			/lib/systemd/system/sysbox-mgr.service && \
 		systemctl daemon-reload && \
 		systemctl restart sysbox.service
+	else
+		sed -i 's|ExecStart=/usr/local/sbin/sysbox-fs|ExecStart=/usr/local/sbin/sysbox-fs --ignore-handler-errors|g' \
+			/lib/systemd/system/sysbox-fs.service && \
+		systemctl daemon-reload && \
+		systemctl restart sysbox.service
+	fi
 
 	set +e
 }
@@ -166,8 +176,13 @@ function build_sysbox() {
 		make clean
 	fi
 
-	echo "Building sysbox ..."
-	make sysbox-local --no-print-directory && make install
+	if [ ! -z "${DEBUG_ON}" ]; then
+		echo "Building sysbox for debugging purposes (unstripped binaries & compiler optimizations off)..."
+		make sysbox-debug-local --no-print-directory && make install
+	else
+		echo "Building sysbox ..."
+		make sysbox-local --no-print-directory && make install
+	fi
 }
 
 function main() {
@@ -188,6 +203,11 @@ function main() {
    # Install sysbox
 	if [[ "$SB_INSTALLER" == "true" ]]; then
 		install_sysbox_pkg
+	elif [ ! -z "$DEBUG_ON" ]; then
+		build_sysbox
+
+		echo "Starting sysbox in debug mode ..."
+		sysbox -d
 	else
 		build_sysbox
 


### PR DESCRIPTION
Goal here is simply to ease Sysbox's troubleshooting process by having debugging targets associated with all the main targets.

New debugging targets are purposely missing a description field to avoid cluttering the existing `make` menu.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>