### PR TITLE
Change sysbox binaries installation path from '/usr/local/sbin' to '/usr/bin'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ PROJECT := /root/nestybox/sysbox
 
 # Sysbox binary targets destination.
 ifeq ($(DESTDIR),)
-INSTALL_DIR := /usr/local/sbin
+INSTALL_DIR := /usr/bin
 else
 INSTALL_DIR := ${DESTDIR}
 endif

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ similar to this:
   "default-runtime": "sysbox-runc",
   "runtimes": {
      "sysbox-runc": {
-        "path": "/usr/local/sbin/sysbox-runc"
+        "path": "/usr/bin/sysbox-runc"
      }
   }
 }

--- a/docs/developers-guide/build.md
+++ b/docs/developers-guide/build.md
@@ -104,7 +104,7 @@ $ sudo make install
 ```
 
 This last target simply copies the Sysbox binaries to your machine's
-`/usr/local/sbin` directory; we don't have a package installer for Sysbox
+`/usr/bin` directory; we don't have a package installer for Sysbox
 (unlike the Sysbox version distributed by Nestybox).
 
 ## Starting Sysbox
@@ -141,7 +141,7 @@ This will add the sysbox-runtime in the `/etc/docker/daemon.json` as follows:
 {
    "runtimes": {
        "sysbox-runc": {
-          "path": "/usr/local/sbin/sysbox-runc"
+          "path": "/usr/bin/sysbox-runc"
        }
    }
 }

--- a/docs/developers-guide/debug.md
+++ b/docs/developers-guide/debug.md
@@ -318,10 +318,10 @@ Instructions:
 4) Point gdb to the sysbox-runc binary so it can load the symbols:
 
 ```console
-    (gdb) file /usr/local/sbin/sysbox-runc
+    (gdb) file /usr/bin/sysbox-runc
     A program is being debugged already.
     Are you sure you want to change the file? (y or n) y
-    Reading symbols from /usr/local/sbin/sysbox-runc...
+    Reading symbols from /usr/bin/sysbox-runc...
     Loading Go Runtime support.
 
     (gdb) bt
@@ -380,4 +380,4 @@ Instructions:
 Tip: if you are running sysbox-runc inside the test container, run gdb at host level,
 use pstree to figure out the pid of sysbox-runc nsenter child process inside the test container,
 and point gdb to the sysbox-runc binary inside the test container (e.g.,
-`file /var/lib/docker/overlay2/860f62b3bd74c36be6754c8ed8e3f77a63744a2c6b16bef058b22ba0185e2877/merged/usr/local/sbin/sysbox-runc`).
+`file /var/lib/docker/overlay2/860f62b3bd74c36be6754c8ed8e3f77a63744a2c6b16bef058b22ba0185e2877/merged/usr/bin/sysbox-runc`).

--- a/docs/quickstart/images.md
+++ b/docs/quickstart/images.md
@@ -30,7 +30,7 @@ Below are the steps:
 {
     "runtimes": {
         "sysbox-runc": {
-            "path": "/usr/local/sbin/sysbox-runc"
+            "path": "/usr/bin/sysbox-runc"
         }
     },
     "default-runtime": "sysbox-runc"

--- a/docs/quickstart/kind.md
+++ b/docs/quickstart/kind.md
@@ -664,7 +664,7 @@ K8s.io KinD + Sysbox).
 {
     "runtimes": {
         "sysbox-runc": {
-            "path": "/usr/local/sbin/sysbox-runc"
+            "path": "/usr/bin/sysbox-runc"
         }
     },
     "default-runtime": "sysbox-runc"

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -39,7 +39,7 @@ In order to reconfigure Sysbox, do the following:
 $ sudo sed -i --follow-symlinks '/^ExecStart/ s/$/ --log-level debug/' /lib/systemd/system/sysbox-fs.service
 $
 $ egrep "ExecStart" /lib/systemd/system/sysbox-fs.service
-ExecStart=/usr/local/sbin/sysbox-fs --log /var/log/sysbox-fs.log --log-level debug
+ExecStart=/usr/bin/sysbox-fs --log /var/log/sysbox-fs.log --log-level debug
 ```
 
 3.  Reload Systemd to digest the previous change:
@@ -128,7 +128,7 @@ You can change the location of the Sysbox data store by passing the
 `--data-root` option to the Sysbox Manager daemon via its associated
 systemd service:
 
-    ExecStart=/usr/local/sbin/sysbox-mgr --data-root /some/other/dir
+    ExecStart=/usr/bin/sysbox-mgr --data-root /some/other/dir
 
 Once reconfigured, restart the Sysbox systemd service as described in
 [Reconfiguration Procedure](#reconfiguration-procedure) above.

--- a/docs/user-guide/install.md
+++ b/docs/user-guide/install.md
@@ -66,7 +66,7 @@ $ sudo systemctl status sysbox -n20
       Tasks: 2 (limit: 9487)
      Memory: 792.0K
      CGroup: /system.slice/sysbox.service
-             ├─2305016 /bin/sh -c /usr/local/sbin/sysbox-runc --version && /usr/local/sbin/sysbox-mgr --version && /usr/local/sbin/sysbox-fs --version && /bin/sleep infinity
+             ├─2305016 /bin/sh -c /usr/bin/sysbox-runc --version && /usr/bin/sysbox-mgr --version && /usr/bin/sysbox-fs --version && /bin/sleep infinity
              └─2305039 /bin/sleep infinity
 
 Mar 27 00:15:36 dev-vm1 systemd[1]: Started Sysbox container runtime.
@@ -110,7 +110,7 @@ configuration to `/etc/docker/daemon.json` and sending a signal (SIGHUP) to Dock
 {
    "runtimes": {
       "sysbox-runc": {
-         "path": "/usr/local/sbin/sysbox-runc"
+         "path": "/usr/bin/sysbox-runc"
       }
    }
 }
@@ -158,7 +158,7 @@ will need to make these changes manually and restart Docker service afterwards (
    "userns-remap": "sysbox",
    "runtimes": {
        "sysbox-runc": {
-          "path": "/usr/local/sbin/sysbox-runc"
+          "path": "/usr/bin/sysbox-runc"
        }
    }
 }

--- a/docs/user-guide/troubleshoot.md
+++ b/docs/user-guide/troubleshoot.md
@@ -104,7 +104,7 @@ The `/etc/docker/daemon.json` file should have an entry for `sysbox-runc` as fol
 {
     "runtimes": {
         "sysbox-runc": {
-            "path": "/usr/local/sbin/sysbox-runc"
+            "path": "/usr/bin/sysbox-runc"
         }
     }
 }
@@ -126,7 +126,7 @@ When creating a system container, Docker may report the following error:
 ```
 # docker run --runtime=sysbox-runc -it --rm nestybox/alpine-docker
 33a50b33f0e23f7ce9c2e42b9c6521d91ab1f833b9b8cd5884d8f32c60dfd144
-docker: Error response from daemon: OCI runtime create failed: unable to retrieve OCI runtime error (open /run/containerd/io.containerd.runtime.v1.linux/moby/33a50b33f0e23f7ce9c2e42b9c6521d91ab1f833b9b8cd5884d8f32c60dfd144/log.json: no such file or directory): /usr/local/sbin/sysbox-runc did not terminate successfully: unknown.
+docker: Error response from daemon: OCI runtime create failed: unable to retrieve OCI runtime error (open /run/containerd/io.containerd.runtime.v1.linux/moby/33a50b33f0e23f7ce9c2e42b9c6521d91ab1f833b9b8cd5884d8f32c60dfd144/log.json: no such file or directory): /usr/bin/sysbox-runc did not terminate successfully: unknown.
 ```
 
 This can occur is distros such as Fedora and CentOS where `shiftfs` is not
@@ -143,7 +143,7 @@ To solve it, please configure Docker with userns-remap as follows:
    "userns-remap": "sysbox",
    "runtimes": {
       "sysbox-runc": {
-         "path": "/usr/local/sbin/sysbox-runc"
+         "path": "/usr/bin/sysbox-runc"
       }
    }
 }
@@ -190,7 +190,7 @@ follows:
    "userns-remap": "sysbox",
    "runtimes": {
       "sysbox-runc": {
-         "path": "/usr/local/sbin/sysbox-runc"
+         "path": "/usr/bin/sysbox-runc"
       }
    }
 }

--- a/scr/docker-cfg
+++ b/scr/docker-cfg
@@ -240,14 +240,14 @@ function docker_config_network() {
 
 		 # If no 'runtimes' key-entry is present, proceed to add one.
 		 if [ $(jq 'has("runtimes")' ${tmpCfgFile}) = "false" ]; then
-			 jq --indent 4 '. + {"runtimes": {"sysbox-runc": {"path": "/usr/local/sbin/sysbox-runc"}}}' \
+			 jq --indent 4 '. + {"runtimes": {"sysbox-runc": {"path": "/usr/bin/sysbox-runc"}}}' \
              ${tmpCfgFile} > ${tmpJqFile} && cp ${tmpJqFile} ${tmpCfgFile}
 
 			 docker_runtime_config_changed="true"
 
 			 # If no 'sysbox-runc' runtime entry is present, proceed to add it.
 		 elif [ $(jq '.runtimes | has("sysbox-runc")' ${tmpCfgFile}) = "false" ]; then
-			 jq --indent 4 '.runtimes |= . + {"sysbox-runc": {"path": "/usr/local/sbin/sysbox-runc"}}' \
+			 jq --indent 4 '.runtimes |= . + {"sysbox-runc": {"path": "/usr/bin/sysbox-runc"}}' \
              ${tmpCfgFile} > ${tmpJqFile} && cp ${tmpJqFile} ${tmpCfgFile}
 
 			 docker_runtime_config_changed="true"

--- a/sysbox-in-docker/Dockerfile.centos-8
+++ b/sysbox-in-docker/Dockerfile.centos-8
@@ -64,8 +64,8 @@ COPY s6-services /etc/services.d/
 COPY sysbox /etc/cont-init.d/
 
 # Copy Sysbox artifacts.
-COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
-COPY sysbox-fs /usr/local/sbin/sysbox-fs
-COPY sysbox-runc /usr/local/sbin/sysbox-runc
+COPY sysbox-mgr /usr/bin/sysbox-mgr
+COPY sysbox-fs /usr/bin/sysbox-fs
+COPY sysbox-runc /usr/bin/sysbox-runc
 
 ENTRYPOINT ["/init"]

--- a/sysbox-in-docker/Dockerfile.debian-bullseye
+++ b/sysbox-in-docker/Dockerfile.debian-bullseye
@@ -71,8 +71,8 @@ COPY s6-services /etc/services.d/
 COPY sysbox /etc/cont-init.d/
 
 # Copy Sysbox artifacts.
-COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
-COPY sysbox-fs /usr/local/sbin/sysbox-fs
-COPY sysbox-runc /usr/local/sbin/sysbox-runc
+COPY sysbox-mgr /usr/bin/sysbox-mgr
+COPY sysbox-fs /usr/bin/sysbox-fs
+COPY sysbox-runc /usr/bin/sysbox-runc
 
 ENTRYPOINT ["/init"]

--- a/sysbox-in-docker/Dockerfile.debian-buster
+++ b/sysbox-in-docker/Dockerfile.debian-buster
@@ -71,8 +71,8 @@ COPY s6-services /etc/services.d/
 COPY sysbox /etc/cont-init.d/
 
 # Copy Sysbox artifacts.
-COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
-COPY sysbox-fs /usr/local/sbin/sysbox-fs
-COPY sysbox-runc /usr/local/sbin/sysbox-runc
+COPY sysbox-mgr /usr/bin/sysbox-mgr
+COPY sysbox-fs /usr/bin/sysbox-fs
+COPY sysbox-runc /usr/bin/sysbox-runc
 
 ENTRYPOINT ["/init"]

--- a/sysbox-in-docker/Dockerfile.fedora-31
+++ b/sysbox-in-docker/Dockerfile.fedora-31
@@ -64,8 +64,8 @@ COPY s6-services /etc/services.d/
 COPY sysbox /etc/cont-init.d/
 
 # Copy Sysbox artifacts.
-COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
-COPY sysbox-fs /usr/local/sbin/sysbox-fs
-COPY sysbox-runc /usr/local/sbin/sysbox-runc
+COPY sysbox-mgr /usr/sbin/sysbox-mgr
+COPY sysbox-fs /usr/bin/sysbox-fs
+COPY sysbox-runc /usr/bin/sysbox-runc
 
 ENTRYPOINT ["/init"]

--- a/sysbox-in-docker/Dockerfile.fedora-32
+++ b/sysbox-in-docker/Dockerfile.fedora-32
@@ -64,8 +64,8 @@ COPY s6-services /etc/services.d/
 COPY sysbox /etc/cont-init.d/
 
 # Copy Sysbox artifacts.
-COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
-COPY sysbox-fs /usr/local/sbin/sysbox-fs
-COPY sysbox-runc /usr/local/sbin/sysbox-runc
+COPY sysbox-mgr /usr/bin/sysbox-mgr
+COPY sysbox-fs /usr/bin/sysbox-fs
+COPY sysbox-runc /usr/bin/sysbox-runc
 
 ENTRYPOINT ["/init"]

--- a/sysbox-in-docker/Dockerfile.ubuntu-bionic
+++ b/sysbox-in-docker/Dockerfile.ubuntu-bionic
@@ -71,8 +71,8 @@ COPY s6-services /etc/services.d/
 COPY sysbox /etc/cont-init.d/
 
 # Copy Sysbox artifacts.
-COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
-COPY sysbox-fs /usr/local/sbin/sysbox-fs
-COPY sysbox-runc /usr/local/sbin/sysbox-runc
+COPY sysbox-mgr /usr/bin/sysbox-mgr
+COPY sysbox-fs /usr/bin/sysbox-fs
+COPY sysbox-runc /usr/bin/sysbox-runc
 
 ENTRYPOINT ["/init"]

--- a/sysbox-in-docker/Dockerfile.ubuntu-focal
+++ b/sysbox-in-docker/Dockerfile.ubuntu-focal
@@ -71,8 +71,8 @@ COPY s6-services /etc/services.d/
 COPY sysbox /etc/cont-init.d/
 
 # Copy Sysbox artifacts.
-COPY sysbox-mgr /usr/local/sbin/sysbox-mgr
-COPY sysbox-fs /usr/local/sbin/sysbox-fs
-COPY sysbox-runc /usr/local/sbin/sysbox-runc
+COPY sysbox-mgr /usr/bin/sysbox-mgr
+COPY sysbox-fs /usr/bin/sysbox-fs
+COPY sysbox-runc /usr/bin/sysbox-runc
 
 ENTRYPOINT ["/init"]

--- a/sysbox-in-docker/s6-services/sysbox-fs/run
+++ b/sysbox-in-docker/s6-services/sysbox-fs/run
@@ -1,3 +1,3 @@
 #!/usr/bin/execlineb -P
 
-/usr/local/sbin/sysbox-fs --ignore-handler-errors --log /var/log/sysbox-fs.log
+/usr/bin/sysbox-fs --ignore-handler-errors --log /var/log/sysbox-fs.log

--- a/sysbox-in-docker/s6-services/sysbox-mgr/run
+++ b/sysbox-in-docker/s6-services/sysbox-mgr/run
@@ -1,3 +1,3 @@
 #!/usr/bin/execlineb -P
 
-/usr/local/sbin/sysbox-mgr --log /var/log/sysbox-mgr.log
+/usr/bin/sysbox-mgr --log /var/log/sysbox-mgr.log

--- a/sysbox-in-docker/sysbox
+++ b/sysbox-in-docker/sysbox
@@ -191,7 +191,7 @@ function docker_setup() {
     "userns-remap": "sysbox",
     "runtimes": {
         "sysbox-runc": {
-            "path": "/usr/local/sbin/sysbox-runc"
+            "path": "/usr/bin/sysbox-runc"
         }
     },
     "bip": "172.25.0.1/16",
@@ -210,7 +210,7 @@ EOF
     "userns-remap": "",
     "runtimes": {
         "sysbox-runc": {
-            "path": "/usr/local/sbin/sysbox-runc",
+            "path": "/usr/bin/sysbox-runc",
             "runtimeArgs": [
                 "--no-kernel-check"
             ]

--- a/tests/helpers/run.bash
+++ b/tests/helpers/run.bash
@@ -102,7 +102,7 @@ function systemd_env() {
 function sysbox_mgr_start() {
 
 	# Note: here we assume sysbox-mgr is started with this command
-	cmd="/usr/local/sbin/sysbox-mgr --log /var/log/sysbox-mgr.log"
+	cmd="/usr/bin/sysbox-mgr --log /var/log/sysbox-mgr.log"
 
 	if [ -n "$SB_INSTALLER" ]; then
 		systemd_unit="/lib/systemd/system/sysbox-mgr.service"
@@ -143,7 +143,7 @@ function sysbox_mgr_stopped() {
 function sysbox_fs_start() {
 
 	# Note: here we assume sysbox-fs is started with this command
-	cmd="/usr/local/sbin/sysbox-fs --log /var/log/sysbox-fs.log"
+	cmd="/usr/bin/sysbox-fs --log /var/log/sysbox-fs.log"
 
 	if [ -n "$SB_INSTALLER" ]; then
 		systemd_unit="/lib/systemd/system/sysbox-fs.service"

--- a/tests/installer/shiftfs_mode.bats
+++ b/tests/installer/shiftfs_mode.bats
@@ -94,7 +94,7 @@ function teardown() {
 {
     "runtimes": {
         "sysbox-runc": {
-            "path": "/usr/local/sbin/sysbox-runc"
+            "path": "/usr/bin/sysbox-runc"
         }
     }
 }
@@ -164,7 +164,7 @@ EOF
 {
     "runtimes": {
         "sysbox-runc": {
-            "path": "/usr/local/sbin/sysbox-runc"
+            "path": "/usr/bin/sysbox-runc"
         }
     }
 }
@@ -238,10 +238,10 @@ EOF
 {
     "runtimes": {
 	      "dummy-runc": {
-		        "path": "/usr/local/sbin/dummy-runc"
+		        "path": "/usr/bin/dummy-runc"
 	      },
 	      "sysbox-runc": {
-		        "path": "/usr/local/sbin/sysbox-runc"
+		        "path": "/usr/bin/sysbox-runc"
 	      }
     }
 }
@@ -316,10 +316,10 @@ EOF
 {
     "runtimes": {
 	      "dummy-runc": {
-		        "path": "/usr/local/sbin/dummy-runc"
+		        "path": "/usr/bin/dummy-runc"
 	      },
 	      "sysbox-runc": {
-		        "path": "/usr/local/sbin/sysbox-runc"
+		        "path": "/usr/bin/sysbox-runc"
 	      }
     }
 }

--- a/tests/installer/userns_mode.bats
+++ b/tests/installer/userns_mode.bats
@@ -95,7 +95,7 @@ function teardown() {
 {
     "runtimes": {
         "sysbox-runc": {
-            "path": "/usr/local/sbin/sysbox-runc"
+            "path": "/usr/bin/sysbox-runc"
         }
     }
 }
@@ -166,7 +166,7 @@ EOF
 {
     "runtimes": {
         "sysbox-runc": {
-            "path": "/usr/local/sbin/sysbox-runc"
+            "path": "/usr/bin/sysbox-runc"
         }
     }
 }
@@ -241,10 +241,10 @@ EOF
 {
     "runtimes": {
 	      "dummy-runc": {
-		        "path": "/usr/local/sbin/dummy-runc"
+		        "path": "/usr/bin/dummy-runc"
 	      },
 	      "sysbox-runc": {
-		        "path": "/usr/local/sbin/sysbox-runc"
+		        "path": "/usr/bin/sysbox-runc"
 	      }
     }
 }
@@ -320,10 +320,10 @@ EOF
 {
     "runtimes": {
 	      "dummy-runc": {
-		        "path": "/usr/local/sbin/dummy-runc"
+		        "path": "/usr/bin/dummy-runc"
 	      },
 	      "sysbox-runc": {
-		        "path": "/usr/local/sbin/sysbox-runc"
+		        "path": "/usr/bin/sysbox-runc"
 	      }
     }
 }
@@ -1015,7 +1015,7 @@ EOF
 {
     "runtimes": {
         "sysbox-runc": {
-            "path": "/usr/local/sbin/sysbox-runc"
+            "path": "/usr/bin/sysbox-runc"
         }
     }
 }
@@ -1104,7 +1104,7 @@ EOF
 {
     "runtimes": {
         "sysbox-runc": {
-            "path": "/usr/local/sbin/sysbox-runc"
+            "path": "/usr/bin/sysbox-runc"
         }
     }
 }

--- a/tests/scr/testContainerInit
+++ b/tests/scr/testContainerInit
@@ -145,14 +145,14 @@ function install_sysbox_pkg() {
 	# (need this flag inside the test container). Also, add '--log-level debug'
 	# knob to sysbox-fs/mgr if requested.
 	if [ -n "$DEBUG_ON" ]; then
-		sed -i 's|ExecStart=/usr/local/sbin/sysbox-fs|ExecStart=/usr/local/sbin/sysbox-fs --log-level debug --ignore-handler-errors|g' \
+		sed -i 's|ExecStart=/usr/bin/sysbox-fs|ExecStart=/usr/bin/sysbox-fs --log-level debug --ignore-handler-errors|g' \
 			/lib/systemd/system/sysbox-fs.service && \
-		sed -i 's|ExecStart=/usr/local/sbin/sysbox-mgr|ExecStart=/usr/local/sbin/sysbox-mgr --log-level debug|g' \
+		sed -i 's|ExecStart=/usr/bin/sysbox-mgr|ExecStart=/usr/bin/sysbox-mgr --log-level debug|g' \
 			/lib/systemd/system/sysbox-mgr.service && \
 		systemctl daemon-reload && \
 		systemctl restart sysbox.service
 	else
-		sed -i 's|ExecStart=/usr/local/sbin/sysbox-fs|ExecStart=/usr/local/sbin/sysbox-fs --ignore-handler-errors|g' \
+		sed -i 's|ExecStart=/usr/bin/sysbox-fs|ExecStart=/usr/bin/sysbox-fs --ignore-handler-errors|g' \
 			/lib/systemd/system/sysbox-fs.service && \
 		systemctl daemon-reload && \
 		systemctl restart sysbox.service
@@ -197,8 +197,8 @@ function main() {
 	trap 'rm -f "${tmpfile}"' EXIT
 
 	# Install helper scripts
-	install -D -m0755 scr/sysbox /usr/local/sbin/sysbox
-	install -D -m0755 scr/docker-cfg /usr/local/sbin/docker-cfg
+	install -D -m0755 scr/sysbox /usr/bin/sysbox
+	install -D -m0755 scr/docker-cfg /usr/bin/docker-cfg
 
    # Install sysbox
 	if [[ "$SB_INSTALLER" == "true" ]]; then


### PR DESCRIPTION
Address issue #221 requirement of changing the executables path to `/usr/bin` from the original `/usr/local/bin` path.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>