### PR TITLE
Fix integration-testcase bug responsible for overlayfs-mount testcase failures

### DIFF
--- a/tests/helpers/syscall.bash
+++ b/tests/helpers/syscall.bash
@@ -165,7 +165,7 @@ function verify_syscont_overlay_umnt() {
   local syscont=$1
   local mnt_path=$2
 
-  docker exec "$syscont" bash -c "mount | grep \"overlay on $mnt_path type overlay"
+  docker exec "$syscont" bash -c "mount | grep \"overlay on $mnt_path type overlay\""
   [ "$status" -eq 1 ]
 
   true


### PR DESCRIPTION
Not sure why problem has not been reproduced till now. The only difference is that now we are relying on a recently built alpine-dbg image which might have some updated bash or something like that ...

```
root@sysbox-test:~/nestybox/sysbox# bats -t tests/syscall/mount/mount-overlayfs.bats
1..6
not ok 1 mount overlayfs basic
```

Signed-off-by: Rodny Molina <rmolina@nestybox.com>