### PR TITLE
Fix bug in shiftfs-mgr test causing bogus failures in CI.

### DIFF
--- a/tests/sysmgr/shiftfsMgr.bats
+++ b/tests/sysmgr/shiftfsMgr.bats
@@ -48,15 +48,15 @@ function teardown() {
   [[ "$output" =~ "/usr/src/linux-headers-${kernel_rel}".+"shiftfs ro,relatime" ]]
 
   # verify things look good on the host
-  run sh -c 'findmnt | grep shiftfs | grep "/lib/modules/${kernel_rel}" | awk "{ print \$3\":\"\$4 }"'
+  run sh -c "findmnt | grep shiftfs | grep \"/lib/modules/${kernel_rel}\""
   [ "$status" -eq 0 ]
   [[ "$output" =~ "/lib/modules/${kernel_rel}".+"shiftfs" ]]
 
-  run sh -c 'findmnt | grep shiftfs | grep "/usr/src/linux-headers-${kernel_rel}" | awk "{ print \$3\":\"\$4 }"'
+  run sh -c "findmnt | grep shiftfs | grep \"/usr/src/linux-headers-${kernel_rel}\""
   [ "$status" -eq 0 ]
   [[ "$output" =~ "/usr/src/linux-headers-${kernel_rel}".+"shiftfs" ]]
 
-  run sh -c 'findmnt | grep shiftfs | grep "/var/lib/docker/containers" | awk "{ print \$3\":\"\$4 }"'
+  run sh -c "findmnt | grep shiftfs | grep \"/var/lib/docker/containers\""
   [ "$status" -eq 0 ]
   [[ "$output" =~ "/var/lib/docker/containers/$SYSCONT_NAME".+"shiftfs" ]]
 


### PR DESCRIPTION
Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>