### PR TITLE
Modify 'testContainerInit' script to skip crio initialization in distros lacking sysbox-pod support [skip ci]

### DIFF
--- a/tests/scr/testContainerInit
+++ b/tests/scr/testContainerInit
@@ -269,6 +269,12 @@ function build_sysbox() {
 	fi
 }
 
+# Returns linux distro running in the system.
+function get_host_distro() {
+	local distro=$(cat /etc/os-release | awk -F"=" '/^ID=/ {print $2}' | tr -d '"')
+	echo $distro
+}
+
 function main() {
 
 	if systemd_env; then
@@ -334,14 +340,18 @@ function main() {
 	echo "Removing left-over Docker containers, volumes, and networks ..."
 	cleanup_docker_env
 
-	# Configure CRI-O
-	crio_config
+	# Configure & initialize CRI-O in scenarios that support Sysbox-POD feature (currently
+	# only in Ubuntu distros).
+	local distro=$(get_host_distro)
+	if [[ "${distro}" = "ubuntu" ]]; then
+		crio_config
 
-	# Start CRI-O (without systemd, we must start CRI-O manually)
-	if systemd_env; then
-		systemctl restart crio
-	else
-		crio > /var/log/crio.log 2>&1 &
+		# Start CRI-O (without systemd, we must start CRI-O manually)
+		if systemd_env; then
+			systemctl restart crio
+		else
+			crio > /var/log/crio.log 2>&1 &
+		fi
 	fi
 
 	if [ -f /sys/fs/cgroup/cgroup.controllers ]; then


### PR DESCRIPTION
Modify 'testContainerInit' script to skip crio initialization in distros lacking sysbox-pod support [skip ci]

Signed-off-by: Rodny Molina <rmolina@nestybox.com>