### PR TITLE
Update sysbox-k8s manifests with the latest changes [skip ci]

### DIFF
--- a/sysbox-k8s-manifests/daemonset/sysbox-cleanup-k8s.yaml
+++ b/sysbox-k8s-manifests/daemonset/sysbox-cleanup-k8s.yaml
@@ -20,7 +20,7 @@ spec:
       - name: sysbox-cleanup-k8s
         image: registry.nestybox.com/nestybox/sysbox-deploy-k8s
         imagePullPolicy: Always
-        command: [ "bash", "-c", "/opt/sysbox/scripts/sysbox-deploy-k8s.sh cleanup" ]
+        command: [ "bash", "-c", "/opt/sysbox/scripts/sysbox-deploy-k8s.sh ce cleanup" ]
         env:
         - name: NODE_NAME
           valueFrom:
@@ -31,22 +31,35 @@ spec:
         volumeMounts:
         - name: host-etc
           mountPath: /mnt/host/etc
+        - name: host-osrelease
+          mountPath: /mnt/host/os-release
         - name: host-dbus
           mountPath: /var/run/dbus
         - name: host-run-systemd
           mountPath: /run/systemd
         - name: host-lib-systemd
-          mountPath: /mnt/host/lib/systemd
+          mountPath: /mnt/host/lib/systemd/system
+        - name: host-etc-systemd
+          mountPath: /mnt/host/etc/systemd/system
         - name: host-usr-bin
-          mountPath: /mnt/host/usr/bin/
+          mountPath: /mnt/host/usr/bin
+        - name: host-opt-bin
+          mountPath: /mnt/host/opt/bin
         - name: host-usr-local-bin
           mountPath: /mnt/host/usr/local/bin
+        - name: host-opt-local-bin
+          mountPath: /mnt/host/opt/local/bin
         - name: host-run
           mountPath: /mnt/host/run
+        - name: host-var-lib
+          mountPath: /mnt/host/var/lib
       volumes:
         - name: host-etc
           hostPath:
             path: /etc
+        - name: host-osrelease
+          hostPath:
+            path: /etc/os-release
         - name: host-dbus
           hostPath:
             path: /var/run/dbus
@@ -55,16 +68,28 @@ spec:
             path: /run/systemd
         - name: host-lib-systemd
           hostPath:
-            path: /lib/systemd
+            path: /lib/systemd/system
+        - name: host-etc-systemd
+          hostPath:
+            path: /etc/systemd/system
         - name: host-usr-bin
           hostPath:
-            path: /usr/bin/
+            path: /usr/bin
+        - name: host-opt-bin
+          hostPath:
+            path: /opt/bin
         - name: host-usr-local-bin
           hostPath:
-            path: /usr/local/bin/
+            path: /usr/local/bin
+        - name: host-opt-local-bin
+          hostPath:
+            path: /opt/local/bin/
         - name: host-run
           hostPath:
             path: /run
+        - name: host-var-lib
+          hostPath:
+            path: /var/lib
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/sysbox-k8s-manifests/daemonset/sysbox-deploy-k8s.yaml
+++ b/sysbox-k8s-manifests/daemonset/sysbox-deploy-k8s.yaml
@@ -20,7 +20,7 @@ spec:
       - name: sysbox-deploy-k8s
         image: registry.nestybox.com/nestybox/sysbox-deploy-k8s
         imagePullPolicy: Always
-        command: [ "bash", "-c", "/opt/sysbox/scripts/sysbox-deploy-k8s.sh install" ]
+        command: [ "bash", "-c", "/opt/sysbox/scripts/sysbox-deploy-k8s.sh ce install" ]
         env:
         - name: NODE_NAME
           valueFrom:
@@ -39,16 +39,28 @@ spec:
           mountPath: /run/systemd
         - name: host-lib-systemd
           mountPath: /mnt/host/lib/systemd/system
+        - name: host-etc-systemd
+          mountPath: /mnt/host/etc/systemd/system
         - name: host-lib-sysctl
           mountPath: /mnt/host/lib/sysctl.d
-        - name: host-usr-lib-mod-load
-          mountPath: /mnt/host/usr/lib/modules-load.d
+        - name: host-opt-lib-sysctl
+          mountPath: /mnt/host/opt/lib/sysctl.d
         - name: host-usr-bin
           mountPath: /mnt/host/usr/bin
+        - name: host-opt-bin
+          mountPath: /mnt/host/opt/bin
         - name: host-usr-local-bin
           mountPath: /mnt/host/usr/local/bin
+        - name: host-opt-local-bin
+          mountPath: /mnt/host/opt/local/bin
+        - name: host-usr-lib-mod-load
+          mountPath: /mnt/host/usr/lib/modules-load.d
+        - name: host-opt-lib-mod-load
+          mountPath: /mnt/host/opt/lib/modules-load.d
         - name: host-run
           mountPath: /mnt/host/run
+        - name: host-var-lib
+          mountPath: /mnt/host/var/lib
       volumes:
         - name: host-etc
           hostPath:
@@ -65,21 +77,39 @@ spec:
         - name: host-lib-systemd
           hostPath:
             path: /lib/systemd/system
+        - name: host-etc-systemd
+          hostPath:
+            path: /etc/systemd/system
         - name: host-lib-sysctl
           hostPath:
             path: /lib/sysctl.d
+        - name: host-opt-lib-sysctl
+          hostPath:
+            path: /opt/lib/sysctl.d
         - name: host-usr-bin
           hostPath:
             path: /usr/bin/
-        - name: host-usr-lib-mod-load
+        - name: host-opt-bin
           hostPath:
-            path: /usr/lib/modules-load.d
+            path: /opt/bin/
         - name: host-usr-local-bin
           hostPath:
             path: /usr/local/bin/
+        - name: host-opt-local-bin
+          hostPath:
+            path: /opt/local/bin/
+        - name: host-usr-lib-mod-load
+          hostPath:
+            path: /usr/lib/modules-load.d
+        - name: host-opt-lib-mod-load
+          hostPath:
+            path: /opt/lib/modules-load.d
         - name: host-run
           hostPath:
             path: /run
+        - name: host-var-lib
+          hostPath:
+            path: /var/lib
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/sysbox-k8s-manifests/daemonset/sysbox-ee-cleanup-k8s.yaml
+++ b/sysbox-k8s-manifests/daemonset/sysbox-ee-cleanup-k8s.yaml
@@ -20,7 +20,7 @@ spec:
       - name: sysbox-ee-cleanup-k8s
         image: registry.nestybox.com/nestybox/sysbox-ee-deploy-k8s
         imagePullPolicy: Always
-        command: [ "bash", "-c", "/opt/sysbox/scripts/sysbox-ee-deploy-k8s.sh cleanup" ]
+        command: [ "bash", "-c", "/opt/sysbox/scripts/sysbox-deploy-k8s.sh ee cleanup" ]
         env:
         - name: NODE_NAME
           valueFrom:
@@ -43,6 +43,8 @@ spec:
           mountPath: /mnt/host/usr/local/bin
         - name: host-run
           mountPath: /mnt/host/run
+        - name: host-var-lib
+          mountPath: /mnt/host/var/lib
       volumes:
         - name: host-etc
           hostPath:
@@ -65,6 +67,9 @@ spec:
         - name: host-run
           hostPath:
             path: /run
+        - name: host-var-lib
+          hostPath:
+            path: /var/lib
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/sysbox-k8s-manifests/daemonset/sysbox-ee-deploy-k8s.yaml
+++ b/sysbox-k8s-manifests/daemonset/sysbox-ee-deploy-k8s.yaml
@@ -20,7 +20,7 @@ spec:
       - name: sysbox-ee-deploy-k8s
         image: registry.nestybox.com/nestybox/sysbox-ee-deploy-k8s
         imagePullPolicy: Always
-        command: [ "bash", "-c", "/opt/sysbox/scripts/sysbox-ee-deploy-k8s.sh install" ]
+        command: [ "bash", "-c", "/opt/sysbox/scripts/sysbox-deploy-k8s.sh ee install" ]
         env:
         - name: NODE_NAME
           valueFrom:
@@ -49,6 +49,8 @@ spec:
           mountPath: /mnt/host/usr/local/bin
         - name: host-run
           mountPath: /mnt/host/run
+        - name: host-var-lib
+          mountPath: /mnt/host/var/lib
       volumes:
         - name: host-etc
           hostPath:
@@ -80,6 +82,9 @@ spec:
         - name: host-run
           hostPath:
             path: /run
+        - name: host-var-lib
+          hostPath:
+            path: /var/lib
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1


### PR DESCRIPTION
This is a summary of the main changes behind these manifest updates:

* Extend sysbox-deploy-k8s.sh to accommodate distro-specific adjustments to be made to the installation logic.
* Expand sysbox-deploy manifests to include a superset of all the bind-mounts that can be potentially required by a given OS distro.
* Consolidate sysbox-deploy-k8s.sh and sysbox-ee-deploy-k8s.sh in a single file.
* Various bug-fixes in the existing code.
* Fix last-minute issue preventing crio & sysbox services from being able to initialize after system boot-up.

Code has been tested in all the supported K8s distros.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>