### PR TITLE
Fix shiftfs dkms repo branch name.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_install:
 
   # Build shiftfs kernel module (not available in GCP's ubuntu-focal machines).
   - sudo apt-get install dkms -y
-  - git clone -b k5.8 https://github.com/toby63/shiftfs-dkms.git shiftfs-k58
-  - cd shiftfs-k58
+  - git clone -b k5.10 https://github.com/toby63/shiftfs-dkms.git shiftfs
+  - cd shiftfs
   - ./update1
   - sudo make -f Makefile.dkms
   - sudo modprobe shiftfs


### PR DESCRIPTION
This change is required as the k5.8 branch is no longer
present in the shiftfs dkms repo.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>