### PR TITLE
Fix permission issues in artifact folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ endif
 export VERSION := $(shell cat ./VERSION)
 export EDITION := Community Edition (CE)
 export PACKAGE := sysbox-ce
+export HOST_UID := $(shell id -u)
+export HOST_GID := $(shell id -g)
 
 # By default, build for amd64
 ARCH := amd64
@@ -179,21 +181,25 @@ DOCKER_SYSBOX_BLD_FLATCAR := docker run --privileged --rm --runtime=runc      \
 sysbox: ## Build sysbox (the build occurs inside a container, so the host is not polluted)
 sysbox: test-img
 	@printf "\n** Building sysbox **\n\n"
-	$(DOCKER_SYSBOX_BLD) /bin/bash -c "buildContainerInit sysbox-local"
+	$(DOCKER_SYSBOX_BLD) /bin/bash -c "export HOST_UID=$(HOST_UID) && \
+		export HOST_GID=$(HOST_GID) && buildContainerInit sysbox-local"
 
 sysbox-flatcar: test-img-flatcar
 	@printf "\n** Building sysbox for Kinvolk's Flatcar OS**\n\n"
-	$(DOCKER_SYSBOX_BLD_FLATCAR) /bin/bash -c "buildContainerInit sysbox-local"
+	$(DOCKER_SYSBOX_BLD_FLATCAR) /bin/bash -c "export HOST_UID=$(HOST_UID) && \
+		export HOST_GID=$(HOST_GID) && buildContainerInit sysbox-local"
 
 sysbox-debug: ## Build sysbox (with debug symbols)
 sysbox-debug: test-img
 	@printf "\n** Building sysbox **\n\n"
-	$(DOCKER_SYSBOX_BLD) /bin/bash -c "buildContainerInit sysbox-debug-local"
+	$(DOCKER_SYSBOX_BLD) /bin/bash -c "export HOST_UID=$(HOST_UID) && \
+		export HOST_GID=$(HOST_GID) && buildContainerInit sysbox-debug-local"
 
 sysbox-static: ## Build sysbox (static linking)
 sysbox-static: test-img
 	@printf "\n** Building sysbox **\n\n"
-	$(DOCKER_SYSBOX_BLD) /bin/bash -c "buildContainerInit sysbox-static-local"
+	$(DOCKER_SYSBOX_BLD) /bin/bash -c "export HOST_UID=$(HOST_UID) && \
+		export HOST_GID=$(HOST_GID) && buildContainerInit sysbox-static-local"
 
 sysbox-local: sysbox-runc sysbox-fs sysbox-mgr
 	@echo $(HOSTNAME)-$(ARCH) > .buildinfo
@@ -235,7 +241,7 @@ sysbox-ipc:
 $(LIBSECCOMP): $(LIBSECCOMP_SRC)
 	@echo "Building libseccomp ..."
 	@cd $(LIBSECCOMP_DIR) && ./autogen.sh && ./configure --host $(HOST_TRIPLE) && make
-	@chown -R rootless:rootless ./sysbox-libs/libseccomp
+	@chown -R $(HOST_UID):$(HOST_GID) ./sysbox-libs/libseccomp
 	@echo "Building libseccomp completed."
 
 #

--- a/tests/scr/buildContainerInit
+++ b/tests/scr/buildContainerInit
@@ -42,8 +42,9 @@ if [[ $distro == "flatcar" ]]; then
 fi
 
 # Fix ownership of artifacts
-chown -R rootless:rootless ./build
-chown -R rootless:rootless ./sysbox-runc
-chown -R rootless:rootless ./sysbox-fs
-chown -R rootless:rootless ./sysbox-mgr
-chown -R rootless:rootless ./sysbox-ipc
+chown -R ${HOST_UID}:${HOST_GID} ./build
+chown -R ${HOST_UID}:${HOST_GID} ./sysbox-runc
+chown -R ${HOST_UID}:${HOST_GID} ./sysbox-fs
+chown -R ${HOST_UID}:${HOST_GID} ./sysbox-mgr
+chown -R ${HOST_UID}:${HOST_GID} ./sysbox-ipc
+chown -R ${HOST_UID}:${HOST_GID} ./sysbox-libs

--- a/tests/scr/buildContainerInit
+++ b/tests/scr/buildContainerInit
@@ -43,8 +43,8 @@ fi
 
 # Fix ownership of artifacts
 chown -R ${HOST_UID}:${HOST_GID} ./build
-chown -R ${HOST_UID}:${HOST_GID} ./sysbox-runc
-chown -R ${HOST_UID}:${HOST_GID} ./sysbox-fs
-chown -R ${HOST_UID}:${HOST_GID} ./sysbox-mgr
+chown -R ${HOST_UID}:${HOST_GID} ./sysbox-runc/build
+chown -R ${HOST_UID}:${HOST_GID} ./sysbox-fs/build
+chown -R ${HOST_UID}:${HOST_GID} ./sysbox-mgr/build
 chown -R ${HOST_UID}:${HOST_GID} ./sysbox-ipc
 chown -R ${HOST_UID}:${HOST_GID} ./sysbox-libs


### PR DESCRIPTION
Multiple EPERM errors are seen when trying to delete artifact folders (make clean):

```
rmolina@dev-vm1:~/wsp/02-26-2020/sysbox$ make clean
cd sysbox-libs/libseccomp && ([ -f ./Makefile ] && make distclean || true)
make[1]: Entering directory '/home/rmolina/wsp/02-26-2020/sysbox/sysbox-libs/libseccomp'
...
 rm -f arch-syscall-check arch-syscall-dump
rm: cannot remove 'libseccomp.la': Permission denied
rm -f ./so_locations
rm: cannot remove '.libs/libseccomp_la-arch-ppc-syscalls.o': Permission denied
rm: cannot remove '.libs/libseccomp_la-arch-ppc.o': Permission denied
rm: cannot remove '.libs/libseccomp_la-arch-s390.o': Permission denied
rm: cannot remove '.libs/libseccomp_la-arch-mips.o': Permission denied
```

This is a consequence of the permissions assigned to the sysbox binaries during compilation, which does not necessarily match those of the user in the host (currently hard-coded to '1000'):

```
rmolina@dev-vm1:~/wsp/02-26-2020/sysbox$ ls -lrt sysbox-fs/build/amd64/
total 21116
-rwxr-xr-x 1 osboxes osboxes 21618904 Sep 15 14:52 sysbox-fs
```

The fix is to ensure that all generated artifacts have ownership matching the uid/gid of the host user.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>