### PR TITLE
Adjust sysbox-k8s uninstallation instructions to address state-compression issue

### DIFF
--- a/docs/user-guide/install-k8s.md
+++ b/docs/user-guide/install-k8s.md
@@ -197,6 +197,7 @@ To uninstall Sysbox:
 kubectl delete runtimeclass sysbox-runc
 kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/daemonset/sysbox-deploy-k8s.yaml
 kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/daemonset/sysbox-cleanup-k8s.yaml
+sleep 30
 kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/daemonset/sysbox-cleanup-k8s.yaml
 kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/rbac/sysbox-deploy-rbac.yaml
 ```
@@ -207,6 +208,7 @@ For Sysbox Enterprise, use the `sysbox-ee-cleanup-k8s.yaml` instead of the `sysb
 kubectl delete runtimeclass sysbox-runc
 kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/daemonset/sysbox-ee-deploy-k8s.yaml
 kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/daemonset/sysbox-ee-cleanup-k8s.yaml
+sleep 30
 kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/daemonset/sysbox-ee-cleanup-k8s.yaml
 kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/rbac/sysbox-deploy-rbac.yaml
 ```
@@ -219,6 +221,9 @@ NOTES:
 -   The uninstallation will temporarily disrupt all pods on the nodes where CRI-O
     and Sysbox were installed, for up to 1 minute, as they require the kubelet to
     restart.
+
+-   The 'sleep' instruction above is to ensure that kubelet has a chance to launch
+    the 'cleanup' daemonset before it is removed in the subsequent step.
 
 ## Upgrading Sysbox or Sysbox Enterprise
 


### PR DESCRIPTION
Problem is observed when the sysbox-k8s uninstallation instructions are executed at once (copy-pasted), as the 'cleanup' daemon-set is being eliminated before this one has a chance to run.

Looks like there's some state-compression issue going on at K8s api level or within the node's kubelet agent itself, even though K8s' api-server is acknowledging that the change has been made as seen below. In either case, without an explicit delay, the sysbox-cleanup-k8s.sh script is never invoked in any of the nodes, so these ones are left with CRI-O as their runtime:

```
$ kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox/k8s-manifests/daemonset/crio-deploy-k8s.yaml
kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox-pods-preview/master/k8s-manifests/daemonset/crio-cleanup-k8s.yaml
kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox-pods-preview/master/k8s-manifests/daemonset/crio-cleanup-k8s.yaml
kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox-pods-preview/master/k8s-manifests/rbac/crio-deploy-rbac.yaml
daemonset.apps "crio-deploy-k8s" deleted
daemonset.apps/crio-cleanup-k8s created
daemonset.apps "crio-cleanup-k8s" deleted
serviceaccount "crio-label-node" deleted
clusterrole.rbac.authorization.k8s.io "crio-node-labeler" deleted
clusterrolebinding.rbac.authorization.k8s.io "crio-label-node-rb" deleted

$ kubectl get nodes -o wide
NAME                                          STATUS   ROLES                  AGE     VERSION   INTERNAL-IP     EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
ip-172-20-42-62.us-west-2.compute.internal    Ready    node                   5h56m   v1.20.6   172.20.42.62    34.217.91.58     Ubuntu 20.04.2 LTS   5.4.0-1045-aws   cri-o://1.20.2
ip-172-20-52-39.us-west-2.compute.internal    Ready    node                   5h56m   v1.20.6   172.20.52.39    54.213.163.125   Ubuntu 20.04.2 LTS   5.4.0-1045-aws   cri-o://1.20.2
ip-172-20-56-13.us-west-2.compute.internal    Ready    node                   5h56m   v1.20.6   172.20.56.13    34.220.174.134   Ubuntu 20.04.2 LTS   5.4.0-1045-aws   cri-o://1.20.2
ip-172-20-56-251.us-west-2.compute.internal   Ready    control-plane,master   5h58m   v1.20.6   172.20.56.251   34.209.48.89     Ubuntu 20.04.2 LTS   5.4.0-1045-aws   containerd://1.4.4
```

Signed-off-by: Rodny Molina <rmolina@nestybox.com>