### PR TITLE
Simplify Sysbox installation on k8s clusters.

### DIFF
--- a/docs/user-guide/install-k8s-distros.md
+++ b/docs/user-guide/install-k8s-distros.md
@@ -122,7 +122,7 @@ the nodes have a minimum of 4 vCPUs each.
 1.  Create a cluster with Kubernetes v1.20 or v1.21.
 
 2.  Create the K8s worker nodes where Sysbox will be installed using the "Ubuntu
-    with Containerd" or the "Ubuntu with Docker" image templates.
+    with Containerd" image templates.
 
     -   Ensure the nodes have a minimum of 4 vCPUs each.
 

--- a/docs/user-guide/install-k8s.md
+++ b/docs/user-guide/install-k8s.md
@@ -96,9 +96,7 @@ Steps:
 
 ```console
 kubectl label nodes <node-name> sysbox-install=yes
-kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/rbac/sysbox-deploy-rbac.yaml
-kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/daemonset/sysbox-deploy-k8s.yaml
-kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/runtime-class/sysbox-runtimeclass.yaml
+kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/sysbox-install.yaml
 ```
 
 **NOTE:** the above step will restart the Kubelet on all nodes where Sysbox is
@@ -124,12 +122,6 @@ Additional notes:
     can live side-by-side with non Sysbox pods and can communicate with them
     according to your K8s networking policy.
 
--   In the past, we used a separate daemonset to install CRI-O. That daemonset
-    is now deprecated, though it can be found [here](../../sysbox-k8s-manifests/daemonset/crio).
-    There is no need to use it any more, as the sysbox-deploy-k8s daemonset now
-    installs both CRI-O and Sysbox on the node (it's faster and simpler to use
-    only one daemonset).
-
 -   If you hit problems, refer to the [troubleshooting sysbox-deploy-k8s](troubleshoot-k8s.md) doc.
 
 ## Installation of Sysbox Enterprise Edition (Sysbox-EE)
@@ -139,13 +131,11 @@ improved security, functionality, performance, life-cycle, and Nestybox support.
 
 The installation for Sysbox Enterprise Edition (Sysbox-EE) in Kubernetes
 clusters is exactly the same as for Sysbox (see [prior section](#installation-of-sysbox)),
-except that you use the `sysbox-ee-deploy-k8s.yaml` instead of `sysbox-deploy-k8s.yaml`:
+except that you use the `sysbox-ee-install.yaml` instead of `sysbox-install.yaml`:
 
 ```console
 kubectl label nodes <node-name> sysbox-install=yes
-kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/rbac/sysbox-deploy-rbac.yaml
-kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/daemonset/sysbox-ee-deploy-k8s.yaml
-kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/runtime-class/sysbox-runtimeclass.yaml
+kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/sysbox-ee-install.yaml
 ```
 
 **NOTE:** either Sysbox or Sysbox Enterprise must be installed on a given host, never both.
@@ -207,23 +197,25 @@ pod limitations.
 To uninstall Sysbox:
 
 ```console
-kubectl delete runtimeclass sysbox-runc
-kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/daemonset/sysbox-deploy-k8s.yaml
-kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/daemonset/sysbox-cleanup-k8s.yaml
+kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/sysbox-install.yaml
+sleep 30
+
+kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/sysbox-uninstall.yaml
 sleep 60
-kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/daemonset/sysbox-cleanup-k8s.yaml
-kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/rbac/sysbox-deploy-rbac.yaml
+
+kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/sysbox-uninstall.yaml
 ```
 
 For Sysbox Enterprise, use the `sysbox-ee-cleanup-k8s.yaml` instead of the `sysbox-cleanup-k8s.yaml`:
 
 ```console
-kubectl delete runtimeclass sysbox-runc
-kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/daemonset/sysbox-ee-deploy-k8s.yaml
-kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/daemonset/sysbox-ee-cleanup-k8s.yaml
+kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/sysbox-ee-install.yaml
+sleep 30
+
+kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/sysbox-ee-uninstall.yaml
 sleep 60
-kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/daemonset/sysbox-ee-cleanup-k8s.yaml
-kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/rbac/sysbox-deploy-rbac.yaml
+
+kubectl delete -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/sysbox-ee-uninstall.yaml
 ```
 
 NOTES:
@@ -235,15 +227,15 @@ NOTES:
     and Sysbox were installed, for up to 1 minute, as they require the kubelet to
     restart.
 
--   The 'sleep' instruction above is to ensure that kubelet has a chance to launch
-    and execute the 'cleanup' daemonset before it is removed in the subsequent step.
+-   The 'sleep' instructions above ensure that kubelet has a chance to launch
+    and execute the daemonsets before the subsequent step.
 
 ## Upgrading Sysbox or Sysbox Enterprise
 
-The [sysbox-deploy-k8s manifest](../../sysbox-k8s-manifests/daemonset/sysbox-deploy-k8s.yaml) points to
-a container image that carries the Sysbox binaries, which the daemonset then
-installs onto the Kubernetes worker nodes. The same applies to the
-[sysbox-ee-deploy-k8s manifest](../../sysbox-k8s-manifests/daemonset/sysbox-ee-deploy-k8s.yaml) for Sysbox Enterprise.
+The [sysbox-install manifest](../../sysbox-k8s-manifests/sysbox-install.yaml) points to
+a container image that carries the Sysbox binaries that are installed
+onto the Kubernetes worker nodes. The same applies to the
+[sysbox-ee-install manifest](../../sysbox-k8s-manifests/sysbox-ee-install.yaml) for Sysbox Enterprise.
 
 Nestybox regularly updates these manifests to point to the container images
 carrying the latest Sysbox and Sysbox Enterprise releases.
@@ -264,8 +256,8 @@ simply [uninstall Sysbox](#uninstallation-of-sysbox-or-sysbox-enterprise) and
 from your K8s clusters as described above.
 
 **NOTE:** While it's possible to have some worker nodes with Sysbox and others
-with Sysbox Enterprise, be aware that the installation & cleanup daemonsets are
-designed to install one or the other, so it's better to install Sysbox or Sysbox
+with Sysbox Enterprise, be aware that the installation daemonsets are designed
+to install one or the other, so it's better to install Sysbox or Sysbox
 Enterprise on a given Kubernetes cluster, never both.
 
 ## Troubleshooting

--- a/docs/user-guide/troubleshoot-k8s.md
+++ b/docs/user-guide/troubleshoot-k8s.md
@@ -1,6 +1,6 @@
 # Sysbox-Deploy-K8s Troubleshooting
 
-This document has troubleshooting tips when installing / using Sysbox on
+This document has troubleshooting tips when installing or using Sysbox on
 Kubernetes clusters.
 
 For troubleshooting outside of Kubernetes environments, see [here](troubleshoot.md).
@@ -29,8 +29,8 @@ Make sure to follow the [Sysbox installation instructions](install-k8s.md) to so
 
 ## sysbox-deploy-k8s fails to install Sysbox
 
-If the sysbox-deploy-k8s fails to install Sysbox, take a look at the logs
-for the sysbox-deploy-k8s pod (there is one such pod for each K8s worker
+If the sysbox-deploy-k8s daemonset fails to install Sysbox, take a look at the
+logs for the sysbox-deploy-k8s pod (there is one such pod for each K8s worker
 node where sysbox is installed). The logs should ideally look like this:
 
 ```console

--- a/sysbox-k8s-manifests/sysbox-ee-install.yaml
+++ b/sysbox-k8s-manifests/sysbox-ee-install.yaml
@@ -1,0 +1,154 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sysbox-label-node
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sysbox-node-labeler
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sysbox-label-node-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sysbox-node-labeler
+subjects:
+- kind: ServiceAccount
+  name: sysbox-label-node
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sysbox-ee-deploy-k8s
+  namespace: kube-system
+spec:
+  selector:
+      matchLabels:
+        sysbox-install: "yes"
+  template:
+    metadata:
+        labels:
+          sysbox-install: "yes"
+    spec:
+      serviceAccountName: sysbox-label-node
+      nodeSelector:
+        sysbox-install: "yes"
+      containers:
+      - name: sysbox-ee-deploy-k8s
+        image: registry.nestybox.com/nestybox/sysbox-ee-deploy-k8s:v0.4.1
+        imagePullPolicy: Always
+        command: [ "bash", "-c", "/opt/sysbox/scripts/sysbox-deploy-k8s.sh ee install" ]
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: host-etc
+          mountPath: /mnt/host/etc
+        - name: host-osrelease
+          mountPath: /mnt/host/os-release
+        - name: host-dbus
+          mountPath: /var/run/dbus
+        - name: host-run-systemd
+          mountPath: /run/systemd
+        - name: host-lib-systemd
+          mountPath: /mnt/host/lib/systemd/system
+        - name: host-etc-systemd
+          mountPath: /mnt/host/etc/systemd/system
+        - name: host-lib-sysctl
+          mountPath: /mnt/host/lib/sysctl.d
+        - name: host-opt-lib-sysctl
+          mountPath: /mnt/host/opt/lib/sysctl.d
+        - name: host-usr-bin
+          mountPath: /mnt/host/usr/bin
+        - name: host-opt-bin
+          mountPath: /mnt/host/opt/bin
+        - name: host-usr-local-bin
+          mountPath: /mnt/host/usr/local/bin
+        - name: host-opt-local-bin
+          mountPath: /mnt/host/opt/local/bin
+        - name: host-usr-lib-mod-load
+          mountPath: /mnt/host/usr/lib/modules-load.d
+        - name: host-opt-lib-mod-load
+          mountPath: /mnt/host/opt/lib/modules-load.d
+        - name: host-run
+          mountPath: /mnt/host/run
+        - name: host-var-lib
+          mountPath: /mnt/host/var/lib
+      volumes:
+        - name: host-etc
+          hostPath:
+            path: /etc
+        - name: host-osrelease
+          hostPath:
+            path: /etc/os-release
+        - name: host-dbus
+          hostPath:
+            path: /var/run/dbus
+        - name: host-run-systemd
+          hostPath:
+            path: /run/systemd
+        - name: host-lib-systemd
+          hostPath:
+            path: /lib/systemd/system
+        - name: host-etc-systemd
+          hostPath:
+            path: /etc/systemd/system
+        - name: host-lib-sysctl
+          hostPath:
+            path: /lib/sysctl.d
+        - name: host-opt-lib-sysctl
+          hostPath:
+            path: /opt/lib/sysctl.d
+        - name: host-usr-bin
+          hostPath:
+            path: /usr/bin/
+        - name: host-opt-bin
+          hostPath:
+            path: /opt/bin/
+        - name: host-usr-local-bin
+          hostPath:
+            path: /usr/local/bin/
+        - name: host-opt-local-bin
+          hostPath:
+            path: /opt/local/bin/
+        - name: host-usr-lib-mod-load
+          hostPath:
+            path: /usr/lib/modules-load.d
+        - name: host-opt-lib-mod-load
+          hostPath:
+            path: /opt/lib/modules-load.d
+        - name: host-run
+          hostPath:
+            path: /run
+        - name: host-var-lib
+          hostPath:
+            path: /var/lib
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+---
+apiVersion: node.k8s.io/v1beta1
+kind: RuntimeClass
+metadata:
+  name: sysbox-runc
+handler: sysbox-runc
+scheduling:
+  nodeSelector:
+    sysbox-runtime: running
+---

--- a/sysbox-k8s-manifests/sysbox-ee-uninstall.yaml
+++ b/sysbox-k8s-manifests/sysbox-ee-uninstall.yaml
@@ -1,0 +1,125 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sysbox-label-node
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sysbox-node-labeler
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sysbox-label-node-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sysbox-node-labeler
+subjects:
+- kind: ServiceAccount
+  name: sysbox-label-node
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sysbox-ee-cleanup-k8s
+  namespace: kube-system
+spec:
+  selector:
+      matchLabels:
+        sysbox-install: "yes"
+  template:
+    metadata:
+        labels:
+          sysbox-install: "yes"
+    spec:
+      serviceAccountName: sysbox-label-node
+      nodeSelector:
+          sysbox-runtime: running
+      containers:
+      - name: sysbox-ee-cleanup-k8s
+        image: registry.nestybox.com/nestybox/sysbox-ee-deploy-k8s:v0.4.1
+        imagePullPolicy: Always
+        command: [ "bash", "-c", "/opt/sysbox/scripts/sysbox-deploy-k8s.sh ee cleanup" ]
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: host-etc
+          mountPath: /mnt/host/etc
+        - name: host-osrelease
+          mountPath: /mnt/host/os-release
+        - name: host-dbus
+          mountPath: /var/run/dbus
+        - name: host-run-systemd
+          mountPath: /run/systemd
+        - name: host-lib-systemd
+          mountPath: /mnt/host/lib/systemd/system
+        - name: host-etc-systemd
+          mountPath: /mnt/host/etc/systemd/system
+        - name: host-usr-bin
+          mountPath: /mnt/host/usr/bin
+        - name: host-opt-bin
+          mountPath: /mnt/host/opt/bin
+        - name: host-usr-local-bin
+          mountPath: /mnt/host/usr/local/bin
+        - name: host-opt-local-bin
+          mountPath: /mnt/host/opt/local/bin
+        - name: host-run
+          mountPath: /mnt/host/run
+        - name: host-var-lib
+          mountPath: /mnt/host/var/lib
+      volumes:
+        - name: host-etc
+          hostPath:
+            path: /etc
+        - name: host-osrelease
+          hostPath:
+            path: /etc/os-release
+        - name: host-dbus
+          hostPath:
+            path: /var/run/dbus
+        - name: host-run-systemd
+          hostPath:
+            path: /run/systemd
+        - name: host-lib-systemd
+          hostPath:
+            path: /lib/systemd/system
+        - name: host-etc-systemd
+          hostPath:
+            path: /etc/systemd/system
+        - name: host-usr-bin
+          hostPath:
+            path: /usr/bin
+        - name: host-opt-bin
+          hostPath:
+            path: /opt/bin
+        - name: host-usr-local-bin
+          hostPath:
+            path: /usr/local/bin
+        - name: host-opt-local-bin
+          hostPath:
+            path: /opt/local/bin/
+        - name: host-run
+          hostPath:
+            path: /run
+        - name: host-var-lib
+          hostPath:
+            path: /var/lib
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+---

--- a/sysbox-k8s-manifests/sysbox-install.yaml
+++ b/sysbox-k8s-manifests/sysbox-install.yaml
@@ -1,0 +1,154 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sysbox-label-node
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sysbox-node-labeler
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sysbox-label-node-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sysbox-node-labeler
+subjects:
+- kind: ServiceAccount
+  name: sysbox-label-node
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sysbox-deploy-k8s
+  namespace: kube-system
+spec:
+  selector:
+      matchLabels:
+        sysbox-install: "yes"
+  template:
+    metadata:
+        labels:
+          sysbox-install: "yes"
+    spec:
+      serviceAccountName: sysbox-label-node
+      nodeSelector:
+        sysbox-install: "yes"
+      containers:
+      - name: sysbox-deploy-k8s
+        image: registry.nestybox.com/nestybox/sysbox-deploy-k8s:v0.4.1
+        imagePullPolicy: Always
+        command: [ "bash", "-c", "/opt/sysbox/scripts/sysbox-deploy-k8s.sh ce install" ]
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: host-etc
+          mountPath: /mnt/host/etc
+        - name: host-osrelease
+          mountPath: /mnt/host/os-release
+        - name: host-dbus
+          mountPath: /var/run/dbus
+        - name: host-run-systemd
+          mountPath: /run/systemd
+        - name: host-lib-systemd
+          mountPath: /mnt/host/lib/systemd/system
+        - name: host-etc-systemd
+          mountPath: /mnt/host/etc/systemd/system
+        - name: host-lib-sysctl
+          mountPath: /mnt/host/lib/sysctl.d
+        - name: host-opt-lib-sysctl
+          mountPath: /mnt/host/opt/lib/sysctl.d
+        - name: host-usr-bin
+          mountPath: /mnt/host/usr/bin
+        - name: host-opt-bin
+          mountPath: /mnt/host/opt/bin
+        - name: host-usr-local-bin
+          mountPath: /mnt/host/usr/local/bin
+        - name: host-opt-local-bin
+          mountPath: /mnt/host/opt/local/bin
+        - name: host-usr-lib-mod-load
+          mountPath: /mnt/host/usr/lib/modules-load.d
+        - name: host-opt-lib-mod-load
+          mountPath: /mnt/host/opt/lib/modules-load.d
+        - name: host-run
+          mountPath: /mnt/host/run
+        - name: host-var-lib
+          mountPath: /mnt/host/var/lib
+      volumes:
+        - name: host-etc
+          hostPath:
+            path: /etc
+        - name: host-osrelease
+          hostPath:
+            path: /etc/os-release
+        - name: host-dbus
+          hostPath:
+            path: /var/run/dbus
+        - name: host-run-systemd
+          hostPath:
+            path: /run/systemd
+        - name: host-lib-systemd
+          hostPath:
+            path: /lib/systemd/system
+        - name: host-etc-systemd
+          hostPath:
+            path: /etc/systemd/system
+        - name: host-lib-sysctl
+          hostPath:
+            path: /lib/sysctl.d
+        - name: host-opt-lib-sysctl
+          hostPath:
+            path: /opt/lib/sysctl.d
+        - name: host-usr-bin
+          hostPath:
+            path: /usr/bin/
+        - name: host-opt-bin
+          hostPath:
+            path: /opt/bin/
+        - name: host-usr-local-bin
+          hostPath:
+            path: /usr/local/bin/
+        - name: host-opt-local-bin
+          hostPath:
+            path: /opt/local/bin/
+        - name: host-usr-lib-mod-load
+          hostPath:
+            path: /usr/lib/modules-load.d
+        - name: host-opt-lib-mod-load
+          hostPath:
+            path: /opt/lib/modules-load.d
+        - name: host-run
+          hostPath:
+            path: /run
+        - name: host-var-lib
+          hostPath:
+            path: /var/lib
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+---
+apiVersion: node.k8s.io/v1beta1
+kind: RuntimeClass
+metadata:
+  name: sysbox-runc
+handler: sysbox-runc
+scheduling:
+  nodeSelector:
+    sysbox-runtime: running
+---

--- a/sysbox-k8s-manifests/sysbox-uninstall.yaml
+++ b/sysbox-k8s-manifests/sysbox-uninstall.yaml
@@ -1,0 +1,125 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sysbox-label-node
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sysbox-node-labeler
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sysbox-label-node-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sysbox-node-labeler
+subjects:
+- kind: ServiceAccount
+  name: sysbox-label-node
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sysbox-cleanup-k8s
+  namespace: kube-system
+spec:
+  selector:
+      matchLabels:
+        sysbox-install: "yes"
+  template:
+    metadata:
+        labels:
+          sysbox-install: "yes"
+    spec:
+      serviceAccountName: sysbox-label-node
+      nodeSelector:
+          sysbox-runtime: running
+      containers:
+      - name: sysbox-cleanup-k8s
+        image: registry.nestybox.com/nestybox/sysbox-deploy-k8s:v0.4.1
+        imagePullPolicy: Always
+        command: [ "bash", "-c", "/opt/sysbox/scripts/sysbox-deploy-k8s.sh ce cleanup" ]
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: host-etc
+          mountPath: /mnt/host/etc
+        - name: host-osrelease
+          mountPath: /mnt/host/os-release
+        - name: host-dbus
+          mountPath: /var/run/dbus
+        - name: host-run-systemd
+          mountPath: /run/systemd
+        - name: host-lib-systemd
+          mountPath: /mnt/host/lib/systemd/system
+        - name: host-etc-systemd
+          mountPath: /mnt/host/etc/systemd/system
+        - name: host-usr-bin
+          mountPath: /mnt/host/usr/bin
+        - name: host-opt-bin
+          mountPath: /mnt/host/opt/bin
+        - name: host-usr-local-bin
+          mountPath: /mnt/host/usr/local/bin
+        - name: host-opt-local-bin
+          mountPath: /mnt/host/opt/local/bin
+        - name: host-run
+          mountPath: /mnt/host/run
+        - name: host-var-lib
+          mountPath: /mnt/host/var/lib
+      volumes:
+        - name: host-etc
+          hostPath:
+            path: /etc
+        - name: host-osrelease
+          hostPath:
+            path: /etc/os-release
+        - name: host-dbus
+          hostPath:
+            path: /var/run/dbus
+        - name: host-run-systemd
+          hostPath:
+            path: /run/systemd
+        - name: host-lib-systemd
+          hostPath:
+            path: /lib/systemd/system
+        - name: host-etc-systemd
+          hostPath:
+            path: /etc/systemd/system
+        - name: host-usr-bin
+          hostPath:
+            path: /usr/bin
+        - name: host-opt-bin
+          hostPath:
+            path: /opt/bin
+        - name: host-usr-local-bin
+          hostPath:
+            path: /usr/local/bin
+        - name: host-opt-local-bin
+          hostPath:
+            path: /opt/local/bin/
+        - name: host-run
+          hostPath:
+            path: /run
+        - name: host-var-lib
+          hostPath:
+            path: /var/lib
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+---


### PR DESCRIPTION
These changes simplify the steps to install sysbox in K8s clusters,
from:

kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/rbac/sysbox-deploy-rbac.yaml
kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/daemonset/sysbox-deploy-k8s.yaml
kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/runtime-class/sysbox-runtimeclass.yaml

to:

kubectl apply -f https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/sysbox-install.yaml

That is, the 3 yamls are merged into a single one. A similar change is done for uninstallation.

The docs have been updated to reflect this change.

Note that for backward compatibility, we leave the old 3 yamls in place. We will
remove them in the future once most users have transitioned to the new (simpler)
installation method.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>