### PR TITLE
Add --seccomp-fd-release flag to the Sysbox startup script.

### DIFF
--- a/scr/sysbox
+++ b/scr/sysbox
@@ -21,6 +21,7 @@ IGNORE_SYSFS_CHOWN=0
 HONOR_CAPS=0
 ALLOW_TRUSTED_XATTR="true"
 SET_DATA_ROOT=0
+SET_SECCOMP_FD_REL=0
 
 # Max number of user-namespaces to configure in distros supporting this knob.
 SYSBOX_MAX_USER_NS=10000
@@ -272,6 +273,10 @@ function sysbox_fs_set_cmdline_opts() {
 		options+=("--ignore-handler-errors")
 	fi
 
+	if [ $SET_SECCOMP_FD_REL -eq 1 ]; then
+		options+=("--seccomp-fd-release=${SECCOMP_FD_REL}")
+	fi
+
 	options+=("--log /var/log/sysbox-fs.log")
 }
 
@@ -343,21 +348,22 @@ function show_usage() {
 	printf "(which are assumed to be installed on the host in the /usr/bin/ directory).\n"
 	printf "\n"
 	printf "Options:\n"
-	printf "  -t, --test-mode               Configures Sysbox in test mode (for use in the Sysbox test suite only).\n"
-	printf "  -d, --debug                   Enables debug logging in Sysbox (useful for debugging).\n"
-	printf "      --data-root <dir>         Path to Sysbox data store (defaults to /var/lib/sysbox).\n"
-	printf "      --disable-shiftfs         Disables Sysbox's use of shiftfs (defaut = false).\n"
-	printf "      --disable-idmapped-mount  Disables Sysbox's use of ID-mapped mounts (default = false).\n"
-	printf "      --disable-rootfs-cloning  Disables rootfs cloning on hosts without shiftfs; setting this option will significantly slow down container startup time (default = false).\n"
-	printf "      --ignore-sysfs-chown      Ignore chown of /sys inside all Sysbox containers; may be needed to run a few apps that chown /sys inside the container (e.g,. rpm). Causes Sysbox to trap the chown syscall inside the container, slowing it down (default = false).\n"
-	printf "      --allow-trusted-xattr     Allows the overlayfs trusted.overlay.opaque xattr to be set inside all Sysbox containers; needed when running Docker inside Sysbox on hosts with kernel < 5.11. Causes Sysbox to trap the *xattr syscalls inside the container, slowing it down (default = true).\n"
-	printf "      --honor-caps              Honor the container's process capabilities passed to Sysbox by the higher level container manager (e.g., Docker/containerd). Without this, Sysbox always gives the container's root user full capabilities and other users no capabilities to mimic a VM-like environment. Note that the container's capabilities are isolated from the host via the Linux user-namespace. (default = false).\n"
-	printf "  -h, --help                    Display usage.\n"
+	printf "  -t, --test-mode                Configures Sysbox in test mode (for use in the Sysbox test suite only).\n"
+	printf "  -d, --debug                    Enables debug logging in Sysbox (useful for debugging).\n"
+	printf "      --data-root <dir>          Path to Sysbox data store (defaults to /var/lib/sysbox).\n"
+	printf "      --disable-shiftfs          Disables Sysbox's use of shiftfs (defaut = false).\n"
+	printf "      --disable-idmapped-mount   Disables Sysbox's use of ID-mapped mounts (default = false).\n"
+	printf "      --disable-rootfs-cloning   Disables rootfs cloning on hosts without shiftfs; setting this option will significantly slow down container startup time (default = false).\n"
+	printf "      --ignore-sysfs-chown       Ignore chown of /sys inside all Sysbox containers; may be needed to run a few apps that chown /sys inside the container (e.g,. rpm). Causes Sysbox to trap the chown syscall inside the container, slowing it down (default = false).\n"
+	printf "      --allow-trusted-xattr      Allows the overlayfs trusted.overlay.opaque xattr to be set inside all Sysbox containers; needed when running Docker inside Sysbox on hosts with kernel < 5.11. Causes Sysbox to trap the *xattr syscalls inside the container, slowing it down (default = true).\n"
+	printf "      --honor-caps               Honor the container's process capabilities passed to Sysbox by the higher level container manager (e.g., Docker/containerd). Without this, Sysbox always gives the container's root user full capabilities and other users no capabilities to mimic a VM-like environment. Note that the container's capabilities are isolated from the host via the Linux user-namespace. (default = false).\n"
+	printf "      --seccomp-fd-release <pol> Policy to close syscall interception handles; useful in kernels < 5.8; allowed values are \"proc-exit\" and \"cont-exit\" (default = \"proc-exit\")\n"
+	printf "  -h, --help                     Display usage.\n"
 	printf "\n"
 }
 
 function parse_args() {
-	options=$(getopt -o tdh -l test-mode,debug,disable-shiftfs,disable-idmapped-mount,disable-rootfs-cloning,ignore-sysfs-chown,honor-caps,allow-trusted-xattr:,data-root:,help -- "$@")
+	options=$(getopt -o tdh -l test-mode,debug,disable-shiftfs,disable-idmapped-mount,disable-rootfs-cloning,ignore-sysfs-chown,honor-caps,allow-trusted-xattr:,data-root:,seccomp-fd-release:,help -- "$@")
 
 	eval set -- "$options"
 
@@ -396,6 +402,11 @@ function parse_args() {
 				SET_DATA_ROOT=1
 				shift
 				DATA_ROOT=$1
+				;;
+			--seccomp-fd-release)
+				SET_SECCOMP_FD_REL=1
+				shift
+				SECCOMP_FD_REL=$1
 				;;
 			--)
 				shift


### PR DESCRIPTION
Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>