### PR TITLE
Address issue preventing apt updates/installations in test-server container

### DIFF
--- a/tests/scr/testContainerInit
+++ b/tests/scr/testContainerInit
@@ -269,6 +269,10 @@ function main() {
 	install -D -m0755 scr/docker-cfg /usr/bin/docker-cfg
 	install -D -m0755 tests/scr/sysbox-docker-cp /usr/bin/sysbox-docker-cp
 
+	# In debian systems (apt-based ones) ensure that the basic dir/file layout
+	# is in place right from the start.
+	mkdir -p /var/lib/dpkg/{alternatives,info,parts,triggers,updates} && touch /var/lib/dpkg/status
+
 	# Install sysbox
 	if [[ "$SB_INSTALLER" == "true" ]]; then
 		install_sysbox_pkg


### PR DESCRIPTION
I've been struggling with this one for a while. Problem is seen often in two of my Ubuntu machines.

Fix is to simply ensure that the expected dir/file layout is in place by the time `apt` instructions are executed. We can remove this one if/when we find the ultimate root-cause of this problem, but for now this is a fairly simple workaround that won't alter in any way properly working scenarios.

```
root@sysbox-test:~/nestybox/sysbox# apt-get update
Get:1 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
Get:2 https://download.docker.com/linux/ubuntu focal InRelease [57.7 kB]
...
Get:26 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 Packages [51.2 kB]
Fetched 21.6 MB in 37s (590 kB/s)
Reading package lists... Error!
E: flAbsPath on /var/lib/dpkg/status failed - realpath (2: No such file or directory)
E: Could not open file  - open (2: No such file or directory)
E: Problem opening
E: The package lists or status file could not be parsed or opened.
root@sysbox-test:~/nestybox/sysbox#
```

Signed-off-by: Rodny Molina <rmolina@nestybox.com>