### PR TITLE
Remove Makefile dependency on lsb_release.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ else
 INSTALL_DIR := ${DESTDIR}
 endif
 
-IMAGE_BASE_DISTRO := $(shell lsb_release -is | tr '[:upper:]' '[:lower:]')
+IMAGE_BASE_DISTRO := $(shell cat /etc/os-release | grep "^ID=" | cut -d "=" -f2)
 
 # Host kernel info
 KERNEL_REL := $(shell uname -r)
@@ -94,10 +94,10 @@ export KERNEL_REL
 
 # Sysbox image-generation globals utilized during the sysbox's building and testing process.
 ifeq ($(IMAGE_BASE_DISTRO),$(filter $(IMAGE_BASE_DISTRO),centos fedora redhat almalinux rocky))
-	IMAGE_BASE_RELEASE := $(shell lsb_release -ds | tr -dc '0-9.' | cut -d'.' -f1)
+	IMAGE_BASE_RELEASE := $(shell cat /etc/os-release | grep "^VERSION_ID" | cut -d "=" -f2)
 	KERNEL_HEADERS := kernels/$(KERNEL_REL)
 else
-	IMAGE_BASE_RELEASE := $(shell lsb_release -cs)
+	IMAGE_BASE_RELEASE := $(shell cat /etc/os-release | grep "^VERSION_CODENAME" | cut -d "=" -f2)
 	ifeq ($(IMAGE_BASE_DISTRO),linuxmint)
 		IMAGE_BASE_DISTRO := ubuntu
 		ifeq ($(IMAGE_BASE_RELEASE),$(filter $(IMAGE_BASE_RELEASE),ulyana ulyssa uma))

--- a/tests/scr/testContainerPre
+++ b/tests/scr/testContainerPre
@@ -8,16 +8,15 @@ TEST_VOL3=$3
 # can't be checked from within the test container since its docker
 # image may be based on another distro)
 
-DISTRO=$(lsb_release -is)
+DISTRO=$(cat /etc/os-release | grep "^ID=" | cut -d "=" -f2)
 
-if [ "$DISTRO" != "Ubuntu" ] &&
-   [ "$DISTRO" != "Debian" ] &&
-   [ "$DISTRO" != "CentOS" ] &&
-   [ "$DISTRO" != "AlmaLinux" ] &&
-   [ "$DISTRO" != "Rocky" ] &&
-   [ "$DISTRO" != "Fedora" ]; then
-    printf "\nError: sysbox is not supported in this distribution: %s.\n\n", $DISTRO
-    exit 1
+if [ "$DISTRO" != "ubuntu" ] &&
+   [ "$DISTRO" != "debian" ] &&
+   [ "$DISTRO" != "centos" ] &&
+   [ "$DISTRO" != "almalinux" ] &&
+   [ "$DISTRO" != "rocky" ] &&
+   [ "$DISTRO" != "fedora" ]; then
+    printf "\nWarning: Sysbox is not supported in this distribution (though it may still work): %s.\n\n", $DISTRO
 fi
 
 # Verify that shiftfs is not mounted at host level (some tests assume this is the case)


### PR DESCRIPTION
The Sysbox Makefile uses the lsb_release command in a few places. However, in
some distros (e.g., fedora), the lsb_release command is not present by default
and installing it requires installing a larger package such as redhat-lsb-core.

This change replaces the use of lsb_release with equivalent parsing of the
"/etc/os-release" file.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>