### PR TITLE
Update sysbox-deploy RuntimeClass yaml to prevent kubectl warning. [skip ci]

### DIFF
--- a/sysbox-k8s-manifests/runtime-class/sysbox-runtimeclass.yaml
+++ b/sysbox-k8s-manifests/runtime-class/sysbox-runtimeclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
   name: sysbox-runc

--- a/sysbox-k8s-manifests/sysbox-ee-install.yaml
+++ b/sysbox-k8s-manifests/sysbox-ee-install.yaml
@@ -143,7 +143,7 @@ spec:
       maxUnavailable: 1
     type: RollingUpdate
 ---
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
   name: sysbox-runc

--- a/sysbox-k8s-manifests/sysbox-install.yaml
+++ b/sysbox-k8s-manifests/sysbox-install.yaml
@@ -143,7 +143,7 @@ spec:
       maxUnavailable: 1
     type: RollingUpdate
 ---
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
   name: sysbox-runc


### PR DESCRIPTION
In k8s >= v1.22, kubectl reports this warning when applying the Sysbox runtime class yaml:

"node.k8s.io/v1beta1 RuntimeClass is deprecated in v1.22+, unavailable in v1.25+"

That's because since v1.20, the API has left beta, so it should be "node.k8s.io/v1"
(see https://kubernetes.io/docs/reference/using-api/deprecation-guide/#runtimeclass-v125).

This commit fixes this.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>