### PR TITLE
Use sysbox static build for sysbox tests.

### DIFF
--- a/tests/scr/testContainerInit
+++ b/tests/scr/testContainerInit
@@ -243,7 +243,7 @@ function build_sysbox() {
 		make sysbox-debug-local --no-print-directory && make install
 	else
 		echo "Building sysbox ..."
-		make sysbox-local --no-print-directory && make install
+		make sysbox-static-local --no-print-directory && make install
 	fi
 }
 


### PR DESCRIPTION
Starting with Sysbox v0.5.0, we use Sysbox static builds for releases to reduce
the number of binaries we need to create in order to run across the different
distros supported by Sysbox. Thus, it makes sense to use static builds for
testing too.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>