### PR TITLE
Update alpine-docker-dbg image in dind test.

### DIFF
--- a/tests/dind/Dockerfile
+++ b/tests/dind/Dockerfile
@@ -1,7 +1,7 @@
-# Note: we use alpine-docker-dbg:3.11 as it comes with Docker 19.03 and helps
-# us avoid sysbox issue #187 (lchown error when Docker v20+ pulls inner images
-# with special devices)
-FROM ghcr.io/nestybox/alpine-docker-dbg:3.11
+# Note: we use alpine-docker-dbg:3.11 or later as it comes with >= Docker 19.03
+# and helps us avoid sysbox issue #187 (lchown error when Docker v20+ pulls
+# inner images with special devices)
+FROM ghcr.io/nestybox/alpine-docker-dbg:3.16
 
 COPY docker-pull.sh /usr/bin
 RUN chmod +x /usr/bin/docker-pull.sh && docker-pull.sh


### PR DESCRIPTION
This allows us to test with the latest alpine + dockerd
versions. It also fixes a problem where the docker daemon
was a bit slow to initialize inside the sysbox container,
causing problems in some dind tests.

Signed-off-by: Cesar Talledo <cesar.talledo@docker.com>