### PR TITLE
Minor tweak to stabilize build-with-inner-images test.

### DIFF
--- a/tests/dind/docker-pull.sh
+++ b/tests/dind/docker-pull.sh
@@ -23,6 +23,7 @@ function retry() {
 
 # dockerd start
 dockerd > /var/log/dockerd.log 2>&1 &
+sleep 2
 retry 10 1 "docker ps"
 
 # pull inner images


### PR DESCRIPTION
Add a delay to allow the docker engine inside a sysbox
container to initialize correctly before asking it
to pull images. Otherwise we sometimes hit TLS handshake
timeouts.

Signed-off-by: Cesar Talledo <cesar.talledo@docker.com>