### PR TITLE
Improve tests on almalinux OSes

### DIFF
--- a/tests/Dockerfile.almalinux-8
+++ b/tests/Dockerfile.almalinux-8
@@ -19,7 +19,7 @@
 # docker build -t sysbox-test .
 #
 
-FROM almalinux:8.5
+FROM almalinux:8
 
 ARG k8s_version=v1.18.2
 
@@ -75,6 +75,8 @@ RUN dnf update -y && dnf install -y \
     attr \
     tree \
     strace \
+    # Package required to build local test sysbox image
+    --enablerepo=powertools glibc-static \
     && echo ". /etc/bash_completion" >> /etc/bash.bashrc \
     && ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa \
     && echo "    StrictHostKeyChecking accept-new" >> /etc/ssh/ssh_config

--- a/tests/Dockerfile.almalinux-9
+++ b/tests/Dockerfile.almalinux-9
@@ -73,6 +73,8 @@ RUN dnf update -y && dnf install -y \
     attr \
     tree \
     strace \
+    # Package required to build local test sysbox image
+    --enablerepo=crb glibc-static \
     && echo ". /etc/bash_completion" >> /etc/bash.bashrc \
     && ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa \
     && echo "    StrictHostKeyChecking accept-new" >> /etc/ssh/ssh_config

--- a/tests/helpers/environment.bash
+++ b/tests/helpers/environment.bash
@@ -28,7 +28,7 @@ function egress_iface_mtu() {
 }
 
 function get_distro() {
-	lsb_release -is | tr '[:upper:]' '[:lower:]'
+	cat /etc/os-release | grep "^ID=" | cut -d "=" -f2 | tr -d '"'
 }
 
 function get_distro_release() {
@@ -36,10 +36,12 @@ function get_distro_release() {
 
 	if [[ ${distro} == centos || \
 		${distro} == redhat || \
+		${distro} == almalinux || \
+		${distro} == rockylinux || \
 		${distro} == fedora ]]; then
-		lsb_release -ds | tr -dc '0-9.' | cut -d'.' -f1
+		cat /etc/os-release | grep "^VERSION_ID" | cut -d "=" -f2 | tr -d '"' | cut -d "." -f1
 	else
-		lsb_release -cs
+		cat /etc/os-release | grep "^VERSION_CODENAME" | cut -d "=" -f2
 	fi
 }
 
@@ -58,6 +60,21 @@ function get_platform() {
 		echo "arm"
 	else
 		echo "unsupported"
+	fi
+}
+
+function get_kernel_headers_path() {
+	local distro=$(get_distro)
+	local kernel_rel=$(get_kernel_release)
+
+	if [[ ${distro} == "centos" || \
+		${distro} == "redhat" || \
+		${distro} == "almalinux" || \
+		${distro} == "rockylinux" || \
+		${distro} == "fedora" ]]; then
+		echo "/usr/src/kernels/${kernel_rel}"
+	else
+		echo "/usr/src/linux-headers-${kernel_rel}"
 	fi
 }
 

--- a/tests/scr/testContainerInit
+++ b/tests/scr/testContainerInit
@@ -280,15 +280,6 @@ function main() {
 		build_sysbox
 	fi
 
-	# Start Sysbox.
-	if [ -n "$DEBUG_ON" ]; then
-		echo "Starting sysbox in debug mode ..."
-		sysbox -d -t
-	else
-		echo "Starting sysbox in test mode ..."
-		sysbox -t
-	fi
-
 	# Start docker (without systemd, we must start Docker manually)
 	if ! systemd_env; then
 		dockerd=$(which dockerd)
@@ -297,6 +288,26 @@ function main() {
 
 	echo "Waiting for Docker to be ready ..."
 	wait_docker_ready || exit 1
+
+	# Start Sysbox.
+	if [ -n "$DEBUG_ON" ]; then
+		if [[ $(docker info | grep "Backing Filesystem" | cut -d " " -f5) != "xfs" ]]; then
+			echo "Starting sysbox in debug mode ..."
+			sysbox -d -t
+		else
+			echo "Starting sysbox in debug mode with idmapped-mount disabled ..."
+			sysbox -d -t --disable-idmapped-mount
+		fi
+	else
+		if [[ $(docker info | grep "Backing Filesystem" | cut -d " " -f5) != "xfs" ]]; then
+			echo "Starting sysbox in test mode ..."
+			sysbox -t
+		else
+			echo "Starting sysbox in test mode with idmapped-mount disabled ..."
+			sysbox -t --disable-idmapped-mount
+		fi
+
+	fi
 
 	# Configure Docker to use Sysbox (leveraging the docker-cfg script)
 	common_opt="--config-only --sysbox-runtime=enable --default-runtime=sysbox-runc"

--- a/tests/scr/testContainerPre
+++ b/tests/scr/testContainerPre
@@ -8,7 +8,7 @@ TEST_VOL3=$3
 # can't be checked from within the test container since its docker
 # image may be based on another distro)
 
-DISTRO=$(cat /etc/os-release | grep "^ID=" | cut -d "=" -f2)
+DISTRO=$(cat /etc/os-release | grep "^ID=" | cut -d "=" -f2 | tr -d '"')
 
 if [ "$DISTRO" != "ubuntu" ] &&
    [ "$DISTRO" != "debian" ] &&

--- a/tests/scr/testSysbox
+++ b/tests/scr/testSysbox
@@ -15,8 +15,8 @@ function idmapped_mount_supported() {
 	local kernel_rel=$(uname -r)
 	local rel_major=$(echo ${kernel_rel} | cut -d'.' -f1)
 	local rel_minor=$(echo ${kernel_rel} | cut -d'.' -f2)
-	[ ${rel_major} -gt 5 ] || ([ ${rel_major} -eq 5 ] && [ ${rel_minor} -ge 12 ])
-	[ $(docker info | grep "Backing Filesystem" | cut -d " " -f5) != "xfs" ] && return 0
+	[ $(docker info | grep "Backing Filesystem" | cut -d " " -f5) != "xfs" ] && \
+		([ ${rel_major} -gt 5 ] || ([ ${rel_major} -eq 5 ] && [ ${rel_minor} -ge 12 ]))
 }
 
 function shiftfs_supported() {

--- a/tests/scr/testSysbox
+++ b/tests/scr/testSysbox
@@ -16,6 +16,7 @@ function idmapped_mount_supported() {
 	local rel_major=$(echo ${kernel_rel} | cut -d'.' -f1)
 	local rel_minor=$(echo ${kernel_rel} | cut -d'.' -f2)
 	[ ${rel_major} -gt 5 ] || ([ ${rel_major} -eq 5 ] && [ ${rel_minor} -ge 12 ])
+	[ $(docker info | grep "Backing Filesystem" | cut -d " " -f5) != "xfs" ] && return 0
 }
 
 function shiftfs_supported() {
@@ -59,8 +60,6 @@ function set_sysbox_shiftfs() {
 }
 
 function run_all_tests() {
-	printf "\nExecuting life-cycle tests ... \n"
-	bats --tap tests/lifecycle
 	printf "\nExecuting sysbox-mgr tests ... \n"
 	bats --tap tests/sysmgr
 	printf "\nExecuting sysbox-fs tests ... \n"
@@ -94,6 +93,8 @@ function run_all_tests() {
 
 	printf "\nSysbox health checking ...\n"
 	bats --tap tests/health/sysbox-health.bats
+	printf "\nExecuting life-cycle tests ... \n"
+	bats --tap tests/lifecycle
 
 	docker system prune -a -f
 }

--- a/tests/scr/testSysboxCI
+++ b/tests/scr/testSysboxCI
@@ -15,8 +15,8 @@ function idmapped_mount_supported() {
 	local kernel_rel=$(uname -r)
 	local rel_major=$(echo ${kernel_rel} | cut -d'.' -f1)
 	local rel_minor=$(echo ${kernel_rel} | cut -d'.' -f2)
-	[ ${rel_major} -gt 5 ] || ( [ ${rel_major} -eq 5 ] && [ ${rel_minor} -ge 12 ] )
-	[ $(docker info | grep "Backing Filesystem" | cut -d " " -f5) != "xfs" ] && return 0
+	[ $(docker info | grep "Backing Filesystem" | cut -d " " -f5) != "xfs" ] && \
+		([ ${rel_major} -gt 5 ] || ( [ ${rel_major} -eq 5 ] && [ ${rel_minor} -ge 12 ] ))
 }
 
 function shiftfs_supported() {

--- a/tests/scr/testSysboxCI
+++ b/tests/scr/testSysboxCI
@@ -16,6 +16,7 @@ function idmapped_mount_supported() {
 	local rel_major=$(echo ${kernel_rel} | cut -d'.' -f1)
 	local rel_minor=$(echo ${kernel_rel} | cut -d'.' -f2)
 	[ ${rel_major} -gt 5 ] || ( [ ${rel_major} -eq 5 ] && [ ${rel_minor} -ge 12 ] )
+	[ $(docker info | grep "Backing Filesystem" | cut -d " " -f5) != "xfs" ] && return 0
 }
 
 function shiftfs_supported() {


### PR DESCRIPTION
- Add necessary package `glibc-static` on almalinux 8 and almalinux 9
- Created a new function to get the kernel headers based on the linux distro.
- Moved the `Start sysbox` block after the initialization of the docker because it is dependend on the docker itself to find out the host filesystem
- Add an extra check regarding the host filesystem. If it is xfs idmapped_mounts is not supported.
- Add the correct kernel header paths in the tests.