### PR TITLE
Simplify git clone in build guide

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "sysbox-fs"]
 	path = sysbox-fs
-	url = git@github.com:nestybox/sysbox-fs.git
+	url = ../sysbox-fs.git
 [submodule "sysbox-runc"]
 	path = sysbox-runc
-	url = git@github.com:nestybox/sysbox-runc.git
+	url = ../sysbox-runc.git
 [submodule "sysbox-ipc"]
 	path = sysbox-ipc
-	url = git@github.com:nestybox/sysbox-ipc.git
+	url = ../sysbox-ipc.git
 [submodule "sysbox-mgr"]
 	path = sysbox-mgr
-	url = git@github.com:nestybox/sysbox-mgr.git
+	url = ../sysbox-mgr.git
 [submodule "sysbox-libs"]
 	path = sysbox-libs
-	url = git@github.com:nestybox/sysbox-libs.git
+	url = ../sysbox-libs.git
 [submodule "sysbox-dockerfiles"]
 	path = sysbox-dockerfiles
-	url = git@github.com:nestybox/dockerfiles.git
+	url = ../dockerfiles.git

--- a/docs/developers-guide/build.md
+++ b/docs/developers-guide/build.md
@@ -39,15 +39,11 @@ scenarios.
 Clone the repo with:
 
 ```
-git clone --recursive git@github.com:nestybox/sysbox.git
+git clone --recursive https://github.com/nestybox/sysbox.git
 ```
 
 Sysbox uses Go modules, so you should clone this into a directory that is
 outside your $GOPATH.
-
-In case of authentication error, make sure your setup is properly configured
-to allow ssh connectivity to Github. Refer to [this](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh)
-doc for details. Or make git use `https` instead of `ssh` by configuring `git config --global url.https://github.com/.insteadOf git@github.com:`.
 
 ## The Sysbox Makefile
 


### PR DESCRIPTION
Using relative urls in the `.gitmodules` configuration will ensure that whatever protocol the user has chosen for cloning the parent repo will be reused in the submodules.

This means it's not mandatory to use SSH for cloning, neither the workaround of adding a `.gitconfig` `insteadOf` entry.

Also, HTTPS is the suggested one since it works without any configuration (neither confirmation).
