### PR TITLE
Minor adjustment to CHANGELOG to avoid packaging error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@ All notable changes to this project will be documented in this file.
   * Increased list of kernels supported by nbox-shiftfs module (refer to nbox-shiftfs module documentation).
   * Add changelog info to the debian package installer.
 
-## [0.0.1] - 2019-07-23
+## [0.0.1] - unreleased
 ### Added
   * Internal release (non-public).
   * Supports launching system containers with Docker.


### PR DESCRIPTION
No official v0.0.1 release was ever generated so no `v0.0.1` tag exists, which ends up causing a few errors during sysbox's package build.