### PR TITLE
Only tests on Amazon Linux 2

### DIFF
--- a/tests/Dockerfile.amzn-2
+++ b/tests/Dockerfile.amzn-2
@@ -19,7 +19,7 @@
 # docker build -t sysbox-test .
 #
 
-FROM amazonlinux:latest
+FROM amazonlinux:2
 
 # Desired platform architecture to build upon.
 ARG sys_arch


### PR DESCRIPTION
Amazon just [GA AL2023](https://aws.amazon.com/blogs/aws/amazon-linux-2023-a-cloud-optimized-linux-distribution-with-long-term-support/) and the `latest` image tag has been updated to point to that of AL2023 instead.

Also, EKS optimized AMI work has not officially begun for AL2023 since there have been significant changes between AL2 and AL2023, e.g. routing, networking, etc.