### PR TITLE
Fix missing dependency in AL2 test image

### DIFF
--- a/tests/Dockerfile.amzn-2
+++ b/tests/Dockerfile.amzn-2
@@ -1,5 +1,5 @@
 #
-# Sysbox Test Container Dockerfile (Fedora-35 image)
+# Sysbox Test Container Dockerfile (Amazonlinux-2 image)
 #
 # This Dockerfile creates the sysbox test container image. The image
 # contains all dependencies needed to build, run, and test sysbox.
@@ -56,6 +56,7 @@ RUN yum update -y && yum install -y \
     libnl3-devel \
     libseccomp \
     libseccomp-devel \
+    libseccomp-static \
     kernel-headers.x86_64 \
     python3 \
     kmod \


### PR DESCRIPTION
The Sysbox build fails when running in the AL2 test image with the following error during the `go build` phase:

```
# github.com/nestybox/sysbox-runc
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: cannot find -lseccomp
/usr/bin/ld: cannot find -lseccomp
collect2: error: ld returned 1 exit status
```

Adding the `libseccomp-static` dependency fixed the issue. It seems to be a regression related with the https://github.com/nestybox/sysbox/commit/ec85fc9221d18ee94e9a5023f8f764bb9821d908 change.

Tested in a EC2 instance running AL2 with `make sysbox-static`, let me know if I need to run any additional tests.