### PR TITLE
Small fix in docker engine restart sequence.

### DIFF
--- a/scr/docker-cfg
+++ b/scr/docker-cfg
@@ -101,9 +101,7 @@ function dockerd_manual_restart() {
 			exit 1
 		fi
 
-		rm -f /var/run/docker.pid
-		rm -f /var/run/docker/containerd/containerd.pid
-		rm -f /var/run/containerd/containerd.pid
+		sleep 1
 
 		$dockerd_cmd > /var/log/dockerd.log 2>&1 &
 


### PR DESCRIPTION
The prior restart sequence worked with Docker Engine 24.0, but fails with Docker Engine 25.0 (docker complains it can't remove its pid file). Upon investigation, found out that a delay was required between stopping the current running docker engine and restarting the new one.