### PR TITLE
fix for ubuntu kernel 6.6+

### DIFF
--- a/scr/sysbox
+++ b/scr/sysbox
@@ -103,19 +103,6 @@ function check_distro_support() {
 	fi
 }
 
-# compares versions and checks if the first is greater or equal to the second
-function geq_version() {
-	currentver=$1
-	requiredver=$2
-	if [ "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" = "$requiredver" ]; then 
-			# Greater than or equal to $requiredver
-			true
-	else
-			# Less than $requiredver
-			false
-	fi
-}
-
 # Ensures unprivileged user-ns's are allowed.
 function setup_userns() {
 	local distro=$1
@@ -124,9 +111,11 @@ function setup_userns() {
 	local out=$(echo "$kver" | grep -q "WSL")
 	local isWSL=$?
 
-	if [ $isWSL -ne 0 ] && ! geq_version "$kver" 6.6.0 ; then
+	if [ $isWSL -ne 0 ]; then
 		if [[ "${distro}" == "ubuntu" ]] ||[[ "${distro}" == "debian" ]]; then
-			echo "1" > /proc/sys/kernel/unprivileged_userns_clone
+			if [ -f "/proc/sys/kernel/unprivileged_userns_clone" ]; then
+				echo "1" > /proc/sys/kernel/unprivileged_userns_clone
+			fi
 		fi
 	fi
 

--- a/scr/sysbox
+++ b/scr/sysbox
@@ -75,7 +75,7 @@ function get_host_distro() {
 	echo $distro
 }
 
-# Returns linux kernerl version in the system.
+# Returns linux kernel version in the system.
 function get_kernel_version() {
 	echo $(uname -r)
 }
@@ -103,6 +103,19 @@ function check_distro_support() {
 	fi
 }
 
+# compares versions and checks if the first is greater or equal to the second
+function geq_version() {
+	currentver=$1
+	requiredver=$2
+	if [ "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" = "$requiredver" ]; then 
+			# Greater than or equal to $requiredver
+			true
+	else
+			# Less than $requiredver
+			false
+	fi
+}
+
 # Ensures unprivileged user-ns's are allowed.
 function setup_userns() {
 	local distro=$1
@@ -111,7 +124,7 @@ function setup_userns() {
 	local out=$(echo "$kver" | grep -q "WSL")
 	local isWSL=$?
 
-	if [ $isWSL -ne 0 ]; then
+	if [ $isWSL -ne 0 ] && ! geq_version "$kver" 6.6.0 ; then
 		if [[ "${distro}" == "ubuntu" ]] ||[[ "${distro}" == "debian" ]]; then
 			echo "1" > /proc/sys/kernel/unprivileged_userns_clone
 		fi

--- a/sysbox-in-docker/sysbox
+++ b/sysbox-in-docker/sysbox
@@ -99,14 +99,30 @@ function check_distro() {
 	fi
 }
 
+# compares versions and checks if the first is greater or equal to the second
+function geq_version() {
+	currentver=$1
+	requiredver=$2
+	if [ "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" = "$requiredver" ]; then 
+			# Greater than or equal to $requiredver
+			true
+	else
+			# Less than $requiredver
+			false
+	fi
+}
+
 # Ensures unprivileged user-ns's are allowed.
 function userns_setup() {
 
   local distro=$1
-
-  if [[ "${distro}" == "ubuntu" ]] ||
-     [[ "${distro}" == "debian" ]]; then
-      echo "1" > /proc/sys/kernel/unprivileged_userns_clone
+  local kver=$2
+  
+  if ! geq_version "$kver" 6.6.0 ; then
+    if [[ "${distro}" == "ubuntu" ]] ||
+      [[ "${distro}" == "debian" ]]; then
+        echo "1" > /proc/sys/kernel/unprivileged_userns_clone
+    fi
   fi
 
   # Setting user-ns max value.
@@ -272,10 +288,28 @@ function sysfs_mount_setup() {
   fi
 }
 
+function geq_version() {
+	currentver=$1
+	requiredver=$2
+	if [ "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" = "$requiredver" ]; then 
+			# Greater than or equal to $requiredver
+			true
+	else
+			# Less than $requiredver
+			false
+	fi
+}
+
+# Returns linux kernel version in the system.
+function get_kernel_version() {
+	echo $(uname -r)
+}
+
 # Completes Sysbox's setup process.
 function sysbox_setup() {
 
   local distro=$(get_host_distro)
+  local kver=$(get_kernel_version)
 
   check_distro "$distro"
 
@@ -284,7 +318,7 @@ function sysbox_setup() {
   fi
 
   setup_sysbox_user
-  userns_setup "$distro"
+  userns_setup "$distro" "$kver"
   kernel_config_setup "$distro"
   sysfs_mount_setup
   docker_setup

--- a/sysbox-in-docker/sysbox
+++ b/sysbox-in-docker/sysbox
@@ -99,29 +99,15 @@ function check_distro() {
 	fi
 }
 
-# compares versions and checks if the first is greater or equal to the second
-function geq_version() {
-	currentver=$1
-	requiredver=$2
-	if [ "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" = "$requiredver" ]; then 
-			# Greater than or equal to $requiredver
-			true
-	else
-			# Less than $requiredver
-			false
-	fi
-}
-
 # Ensures unprivileged user-ns's are allowed.
 function userns_setup() {
 
   local distro=$1
-  local kver=$2
-  
-  if ! geq_version "$kver" 6.6.0 ; then
-    if [[ "${distro}" == "ubuntu" ]] ||
-      [[ "${distro}" == "debian" ]]; then
-        echo "1" > /proc/sys/kernel/unprivileged_userns_clone
+
+  if [[ "${distro}" == "ubuntu" ]] ||
+     [[ "${distro}" == "debian" ]]; then
+    if [ -f "/proc/sys/kernel/unprivileged_userns_clone" ]; then
+      echo "1" > /proc/sys/kernel/unprivileged_userns_clone
     fi
   fi
 
@@ -288,28 +274,10 @@ function sysfs_mount_setup() {
   fi
 }
 
-function geq_version() {
-	currentver=$1
-	requiredver=$2
-	if [ "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" = "$requiredver" ]; then 
-			# Greater than or equal to $requiredver
-			true
-	else
-			# Less than $requiredver
-			false
-	fi
-}
-
-# Returns linux kernel version in the system.
-function get_kernel_version() {
-	echo $(uname -r)
-}
-
 # Completes Sysbox's setup process.
 function sysbox_setup() {
 
   local distro=$(get_host_distro)
-  local kver=$(get_kernel_version)
 
   check_distro "$distro"
 
@@ -318,7 +286,7 @@ function sysbox_setup() {
   fi
 
   setup_sysbox_user
-  userns_setup "$distro" "$kver"
+  userns_setup "$distro"
   kernel_config_setup "$distro"
   sysfs_mount_setup
   docker_setup


### PR DESCRIPTION
Fixes #780 No such file or directory - unprivileged_userns_clone

I'm currently testing this on ubuntu 20.04 with kernel 6.8.10, but I wanted to get this out for feedback and to see if other people wanted to test it.