### PR TITLE
Fix breakage in syscont dns user-bridge test.

### DIFF
--- a/tests/docker/dns.bats
+++ b/tests/docker/dns.bats
@@ -120,17 +120,17 @@ function teardown() {
      [[ "$output" == "$gateway" ]]
 
      # DNAT
-     docker exec "$syscont" sh -c "nft list chain nat DOCKER_OUTPUT | egrep -q \"ip daddr ${gateway} tcp\""
+     docker exec "$syscont" sh -c "nft list chain nat DOCKER_OUTPUT | egrep -q \"ip daddr ${gateway} tcp|tcp ip daddr ${gateway}\""
      [ "$status" -eq 0 ]
 
-     docker exec "$syscont" sh -c "nft list chain nat DOCKER_OUTPUT | egrep -q \"ip daddr ${gateway} udp\""
+     docker exec "$syscont" sh -c "nft list chain nat DOCKER_OUTPUT | egrep -q \"ip daddr ${gateway} udp|udp ip daddr ${gateway}\""
      [ "$status" -eq 0 ]
 
      # SNAT
-     docker exec "$syscont" sh -c "nft list chain nat DOCKER_POSTROUTING | egrep -q \"ip saddr 127.0.0.11 tcp\""
+     docker exec "$syscont" sh -c "nft list chain nat DOCKER_POSTROUTING | egrep -q \"ip saddr 127.0.0.11 tcp|tcp ip saddr 127.0.0.11\""
      [ "$status" -eq 0 ]
 
-     docker exec "$syscont" sh -c "nft list chain nat DOCKER_POSTROUTING | egrep -q \"ip saddr 127.0.0.11 udp\""
+     docker exec "$syscont" sh -c "nft list chain nat DOCKER_POSTROUTING | egrep -q \"ip saddr 127.0.0.11 udp|udp ip saddr 127.0.0.11\""
      [ "$status" -eq 0 ]
   fi
 


### PR DESCRIPTION
A recent commit (a6e09bf3) modified the way the syscont dns user-bridge test checks the output of nftables. The commit meant to make the check more generic across distros, particularly to enable Sysbox development on Rockylinux.

However the test now fails on my Ubuntu Jammy host (kernel 6.5.0-35-generic). It therefore seems that the output of nftables differs depending on the nftables or linux kernel version.

This commit improves the failing test to better parse the nftable output across different versions.