### PR TITLE
Add image for fedora 40

### DIFF
--- a/tests/Dockerfile.fedora-40
+++ b/tests/Dockerfile.fedora-40
@@ -1,0 +1,170 @@
+#
+# Sysbox Test Container Dockerfile (Fedora-37 image)
+#
+# This Dockerfile creates the sysbox test container image. The image
+# contains all dependencies needed to build, run, and test sysbox.
+#
+# The image does not contain sysbox itself; the sysbox repo
+# must be bind mounted into the image. It can then be built,
+# installed, and executed within the container.
+#
+# The image must be run as a privileged container (i.e., docker run --privileged ...)
+# Refer to the sysbox Makefile test targets.
+#
+# This Dockerfile is based on a similar Dockerfile in the OCI runc
+# github repo, but adapted to sysbox testing.
+#
+# Instructions:
+#
+# docker build -t sysbox-test .
+#
+
+FROM fedora:40
+
+# Desired platform architecture to build upon.
+ARG sys_arch
+ENV SYS_ARCH=${sys_arch}
+ARG target_arch
+ENV TARGET_ARCH=${target_arch}
+
+ARG k8s_version=v1.20.2
+
+RUN dnf update -y && dnf install -y \
+    acl \
+    yum-utils \
+    automake \
+    autoconf \
+    libtool \
+    procps \
+    psmisc \
+    nano \
+    less \
+    curl \
+    sudo \
+    gawk \
+    git \
+    iptables \
+    iproute \
+    jq \
+    pkg-config \
+    libaio-devel \
+    libcap-devel \
+    libnl3-devel \
+    libseccomp \
+    libseccomp-devel \
+		libseccomp-static \
+    python3 \
+    kmod \
+    unzip \
+    time \
+    net-tools \
+    wget \
+    lsof \
+    iputils \
+    ca-certificates \
+    bc \
+    # sysbox deps
+    fuse \
+    rsync \
+    redhat-lsb-core \
+    bash-completion \
+    attr \
+    tree \
+    strace \
+    && echo ". /etc/bash_completion" >> /etc/bash.bashrc \
+    && ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa \
+    && echo "    StrictHostKeyChecking accept-new" >> /etc/ssh/ssh_config
+
+# install cross compile tool chains
+RUN dnf copr enable -y lantw44/aarch64-linux-gnu-toolchain \
+    && dnf copr enable -y lantw44/arm-linux-gnueabi-toolchain \
+    && dnf copr enable -y lantw44/arm-linux-gnueabihf-toolchain \
+    && dnf install -y \
+    arm-linux-gnueabi-gcc \
+    arm-linux-gnueabi-glibc \
+    arm-linux-gnueabi-binutils \
+    arm-linux-gnueabihf-gcc \
+    arm-linux-gnueabihf-glibc \
+    arm-linux-gnueabihf-binutils \
+    aarch64-linux-gnu-gcc \
+    aarch64-linux-gnu-glibc \
+    aarch64-linux-gnu-binutils
+
+# Install Golang
+RUN wget https://go.dev/dl/go1.22.6.linux-${sys_arch}.tar.gz && \
+    tar -C /usr/local -xzf go1.22.6.linux-${sys_arch}.tar.gz && \
+    /usr/local/go/bin/go env -w GONOSUMDB=/root/nestybox
+
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+RUN go env -w GONOSUMDB=/root/nestybox && \
+    mkdir -p "$GOPATH/src" "$GOPATH/bin" && \
+    chmod -R 777 "$GOPATH"
+
+# Add a dummy user for the rootless integration tests; needed by the
+# `git clone` operations below.
+RUN useradd -u1000 -m -d/home/rootless -s/bin/bash rootless
+
+# install bats
+RUN cd /tmp \
+    && git clone https://github.com/sstephenson/bats.git \
+    && cd bats \
+    && git reset --hard 03608115df2071fff4eaaff1605768c275e5f81f \
+    && ./install.sh /usr/local \
+    && rm -rf /tmp/bats
+
+# install protoc compiler for gRPC
+RUN if [ "$sys_arch" = "amd64" ] ; then arch_str="x86_64"; \
+    elif [ "$sys_arch" = "arm64" ]; then arch_str="aarch_64"; \
+    else echo "Unsupported platform: ${sys_arch}"; exit; fi \
+    && curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-${arch_str}.zip \
+    && unzip protoc-3.15.8-linux-${arch_str}.zip -d $HOME/.local \
+    && export PATH="$PATH:$HOME/.local/bin" \
+     && ln -s $HOME/.local/bin/protoc /usr/local/bin/protoc \
+    && go install github.com/golang/protobuf/protoc-gen-go@latest \
+    && export PATH="$PATH:$(go env GOPATH)/bin"
+
+# Install Kubectl for K8s integration-testing. Notice that we are explicitly
+# stating the kubectl version to download, which should match the K8s release
+# deployed in K8s (L2) nodes.
+RUN curl -LO https://dl.k8s.io/release/${k8s_version}/bin/linux/${sys_arch}/kubectl \
+    && install -o root -g root -m 0755 kubectl /usr/bin/kubectl
+
+# install Docker (used by most sysbox tests to launch sys containers)
+RUN dnf update -y \
+    && dnf config-manager --add-repo=https://download.docker.com/linux/fedora/docker-ce.repo \
+    && dnf install -y docker-ce --nobest
+ADD https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker \
+    /etc/bash_completion.d/docker.sh
+
+# Go Dlv for debugging
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+# Use the old definition for SECCOMP_NOTIF_ID_VALID in /usr/include/linux/seccomp.h
+#
+# This is needed because the definition changed in the mainline kernel
+# on 06/2020 (from SECCOMP_IOR -> SECCOMP_IOW), and some distros we
+# support have picked it up in their latest releases / kernels
+# updates. The kernel change was backward compatible, so by using the
+# old definition, we are guaranteed it will work on kernels before and
+# after the change. On the other hand, if we were to use the new
+# definition, seccomp notify would fail when sysbox runs in old
+# kernels.
+RUN sed -i 's/^#define SECCOMP_IOCTL_NOTIF_ID_VALID[ \t]*SECCOMP_IOW(2, __u64)/#define SECCOMP_IOCTL_NOTIF_ID_VALID   SECCOMP_IOR(2, __u64)/g' /usr/include/linux/seccomp.h
+
+# Libc needed to statically compile Sysbox
+RUN dnf update -y && dnf install -y glibc-static
+
+# sysbox env
+RUN useradd sysbox \
+    && mkdir -p /var/lib/sysboxfs
+
+# test scripts
+COPY scr/testContainerInit /usr/bin
+COPY scr/testContainerCleanup /usr/bin
+COPY scr/buildContainerInit /usr/bin
+COPY bin/userns_child_exec_${sys_arch} /usr/bin
+
+RUN mkdir -p /root/nestybox
+WORKDIR /root/nestybox/sysbox
+CMD /bin/bash

--- a/tests/Dockerfile.fedora-40
+++ b/tests/Dockerfile.fedora-40
@@ -52,7 +52,7 @@ RUN dnf update -y && dnf install -y \
     libnl3-devel \
     libseccomp \
     libseccomp-devel \
-		libseccomp-static \
+    libseccomp-static \
     python3 \
     kmod \
     unzip \


### PR DESCRIPTION
i have a system running fedora 40. the documentation says that support for fedora is wip, and the supported versions are from 34-37. since it is not feasible for me to install ubuntu, i decided to compile sysbox from source. copied the Dockerfile for 37, added `libseccomp-static` in the `dnf install` step, and sysbox seems to be running just fine on fedora 40.

happy to update the doc as well if needed.