### PR TITLE
Update sysbox-deploy-k8s manifests as per new features

### DIFF
--- a/sysbox-k8s-manifests/sysbox-install.yaml
+++ b/sysbox-k8s-manifests/sysbox-install.yaml
@@ -13,6 +13,9 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "patch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "delete", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/sysbox-k8s-manifests/sysbox-install.yaml
+++ b/sysbox-k8s-manifests/sysbox-install.yaml
@@ -27,6 +27,15 @@ subjects:
   name: sysbox-label-node
   namespace: kube-system
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sysbox-operational-attributes
+  namespace: kube-system
+data:
+  SYSBOX_MGR_CONFIG: ""
+  SYSBOX_FS_CONFIG: ""
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -59,6 +68,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: SYSBOX_MGR_CONFIG
+          valueFrom:
+            configMapKeyRef:
+              name: sysbox-operational-attributes
+              key: SYSBOX_MGR_CONFIG
+        - name: SYSBOX_FS_CONFIG
+          valueFrom:
+            configMapKeyRef:
+              name: sysbox-operational-attributes
+              key: SYSBOX_FS_CONFIG
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
* sysbox-deploy-k8s daemonset now allows users to specify the desired configuration for the sysbox-fs/mgr daemons.
* sysbox-deploy-k8s now ensures that preexisting sysbox pods are eliminated during upgrade/installation.