### PR TITLE
Update K8s installation in a few Sysbox test container images.

### DIFF
--- a/tests/Dockerfile.almalinux-8
+++ b/tests/Dockerfile.almalinux-8
@@ -21,7 +21,7 @@
 
 FROM almalinux:8
 
-ARG k8s_version=v1.18.2
+ARG k8s_version=v1.28.2
 
 # Desired platform architecture to build upon.
 ARG sys_arch
@@ -31,9 +31,9 @@ ENV TARGET_ARCH=${target_arch}
 
 # CRI-O & crictl version for testing sysbox pods; CRI-O 1.20 is required as it
 # introduces rootless pod support (via the Linux user-ns)
-ARG crio_version=1.22
+ARG crio_version=1.28
 ARG crio_os=CentOS_8
-ARG crictl_version=v1.20.0
+ARG crictl_version=v1.28.0
 
 RUN dnf update -y && dnf install -y \
     acl \
@@ -114,25 +114,12 @@ RUN if [ "$sys_arch" = "amd64" ] ; then arch_str="x86_64"; \
     && go install github.com/golang/protobuf/protoc-gen-go@latest \
     && export PATH="$PATH:$(go env GOPATH)/bin"
 
-# Install Kubectl for K8s integration-testing. Notice that we are explicitly
+# Install Kubectl for k8s-in-docker integration-testing. Notice that we are explicitly
 # stating the kubectl version to download, which should match the K8s release
-# deployed in K8s (L2) nodes.
-#
-# TODO: Define a mechanism in our testing-framework to allow K8s version to be
-# configured in a centralized location, so that the installed K8s components
-# (both inside privileged test-container and within L2 K8s image) are all
-# matching the same K8s release.
-RUN echo -e "\
-[kubernetes] \n\
-name=Kubernetes \n\
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64 \n\
-enabled=1 \n\
-gpgcheck=1 \n\
-repo_gpgcheck=1 \n\
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg \
-" > /etc/yum.repos.d/kubernetes.repo \
-    && yum update -y \
-    && yum install -y kubectl --nobest
+# deployed in the K8s-in-docker nodes (L2).
+RUN cd /tmp && curl -LO "https://dl.k8s.io/release/${k8s_version}/bin/linux/amd64/kubectl" \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl \
+    && rm /tmp/kubectl
 
 # CRI-O and crictl for testing deployment of pods with sysbox (aka "sysbox pods")
 RUN curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/${crio_os}/devel:kubic:libcontainers:stable.repo \

--- a/tests/Dockerfile.almalinux-9
+++ b/tests/Dockerfile.almalinux-9
@@ -21,7 +21,7 @@
 
 FROM almalinux:9
 
-ARG k8s_version=v1.18.2
+ARG k8s_version=v1.28.2
 
 # Desired platform architecture to build upon.
 ARG sys_arch
@@ -31,8 +31,8 @@ ENV TARGET_ARCH=${target_arch}
 
 # CRI-O & crictl version for testing sysbox pods; CRI-O 1.20 is required as it
 # introduces rootless pod support (via the Linux user-ns)
-ARG crio_version=v1.24.1
-ARG crictl_version=v1.20.0
+ARG crio_version=1.28
+ARG crictl_version=v1.28.0
 
 RUN dnf update -y && dnf install -y \
     acl \
@@ -112,25 +112,12 @@ RUN if [ "$sys_arch" = "amd64" ] ; then arch_str="x86_64"; \
     && go install github.com/golang/protobuf/protoc-gen-go@latest \
     && export PATH="$PATH:$(go env GOPATH)/bin"
 
-# Install Kubectl for K8s integration-testing. Notice that we are explicitly
+# Install Kubectl for k8s-in-docker integration-testing. Notice that we are explicitly
 # stating the kubectl version to download, which should match the K8s release
-# deployed in K8s (L2) nodes.
-#
-# TODO: Define a mechanism in our testing-framework to allow K8s version to be
-# configured in a centralized location, so that the installed K8s components
-# (both inside privileged test-container and within L2 K8s image) are all
-# matching the same K8s release.
-RUN echo -e "\
-[kubernetes] \n\
-name=Kubernetes \n\
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64 \n\
-enabled=1 \n\
-gpgcheck=1 \n\
-repo_gpgcheck=1 \n\
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg \
-" > /etc/yum.repos.d/kubernetes.repo \
-    && dnf update -y \
-    && dnf install -y kubectl --nobest
+# deployed in the K8s-in-docker nodes (L2).
+RUN cd /tmp && curl -LO "https://dl.k8s.io/release/${k8s_version}/bin/linux/amd64/kubectl" \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl \
+    && rm /tmp/kubectl
 
 # CRI-O and crictl for testing deployment of pods with sysbox (aka "sysbox pods")
 RUN curl -LO https://storage.googleapis.com/cri-o/artifacts/cri-o.${sys_arch}.${crio_version}.tar.gz \

--- a/tests/Dockerfile.debian-bullseye
+++ b/tests/Dockerfile.debian-bullseye
@@ -29,13 +29,13 @@ ENV TARGET_ARCH=${target_arch}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG k8s_version=v1.20.2
+ARG k8s_version=v1.28.2
 
 # CRI-O & crictl version for testing sysbox pods; CRI-O 1.20 is required as it
 # introduces rootless pod support (via the Linux user-ns)
-ARG crio_version=1.20
+ARG crio_version=1.28
 ARG crio_os=Debian_11
-ARG crictl_version=v1.20.0
+ARG crictl_version=v1.28.0
 
 RUN apt-get update && apt-get install -y \
     acl \
@@ -141,16 +141,6 @@ RUN curl -fsSL https://get.docker.com -o get-docker.sh \
     && sh get-docker.sh
 ADD https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker /etc/bash_completion.d/docker.sh
 
-# Install Kubectl for K8s integration-testing. Notice that we are explicitly
-# stating the kubectl version to download, which should match the K8s release
-# deployed in K8s (L2) nodes.
-RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -  \
-    && echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list \
-    && apt-get update \
-    && apt-get install kubectl="${k8s_version#v}"-00 \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
-
 # shellcheck for lint of shell scripts
 RUN apt-get update && apt-get install -y shellcheck
 
@@ -160,12 +150,9 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest
 # Install Kubectl for k8s-in-docker integration-testing. Notice that we are explicitly
 # stating the kubectl version to download, which should match the K8s release
 # deployed in the K8s-in-docker nodes (L2).
-RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -  \
-    && echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list \
-    && apt-get update \
-    && apt-get install kubectl:${sys_arch}="${k8s_version#v}"-00 \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+RUN cd /tmp && curl -LO "https://dl.k8s.io/release/${k8s_version}/bin/linux/amd64/kubectl" \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl \
+    && rm /tmp/kubectl
 
 # CRI-O and crictl for testing deployment of pods with sysbox (aka "sysbox pods")
 RUN echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/${crio_os}/ /"| tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list \

--- a/tests/Dockerfile.debian-buster
+++ b/tests/Dockerfile.debian-buster
@@ -29,13 +29,13 @@ ENV TARGET_ARCH=${target_arch}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG k8s_version=v1.20.2
+ARG k8s_version=v1.28.2
 
-# CRI-O & crictl version for testing sysbox pods; CRI-O 1.20 is required as it
+# CRI-O & crictl version for testing sysbox pods; CRI-O > 1.20 is required as it
 # introduces rootless pod support (via the Linux user-ns)
-ARG crio_version=1.20
+ARG crio_version=1.28
 ARG crio_os=Debian_10
-ARG crictl_version=v1.20.0
+ARG crictl_version=v1.28.0
 
 RUN apt-get update && apt-get install -y \
     acl \
@@ -143,16 +143,6 @@ RUN curl -fsSL https://get.docker.com -o get-docker.sh \
     && sh get-docker.sh
 ADD https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker /etc/bash_completion.d/docker.sh
 
-# Install Kubectl for K8s integration-testing. Notice that we are explicitly
-# stating the kubectl version to download, which should match the K8s release
-# deployed in K8s (L2) nodes.
-RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -  \
-    && echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list \
-    && apt-get update \
-    && apt-get install kubectl="${k8s_version#v}"-00 \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
-
 # shellcheck for lint of shell scripts
 RUN apt-get update && apt-get install -y shellcheck
 
@@ -162,12 +152,9 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest
 # Install Kubectl for k8s-in-docker integration-testing. Notice that we are explicitly
 # stating the kubectl version to download, which should match the K8s release
 # deployed in the K8s-in-docker nodes (L2).
-RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -  \
-    && echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list \
-    && apt-get update \
-    && apt-get install kubectl:${sys_arch}="${k8s_version#v}"-00 \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+RUN cd /tmp && curl -LO "https://dl.k8s.io/release/${k8s_version}/bin/linux/amd64/kubectl" \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl \
+    && rm /tmp/kubectl
 
 # CRI-O and crictl for testing deployment of pods with sysbox (aka "sysbox pods")
 RUN echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/${crio_os}/ /"| tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list \

--- a/tests/Dockerfile.rocky-8
+++ b/tests/Dockerfile.rocky-8
@@ -21,7 +21,7 @@
 
 FROM rockylinux:8.5
 
-ARG k8s_version=v1.18.2
+ARG k8s_version=v1.28.2
 
 # Desired platform architecture to build upon.
 ARG sys_arch
@@ -31,9 +31,9 @@ ENV TARGET_ARCH=${target_arch}
 
 # CRI-O & crictl version for testing sysbox pods; CRI-O 1.20 is required as it
 # introduces rootless pod support (via the Linux user-ns)
-ARG crio_version=1.22
+ARG crio_version=1.28
 ARG crio_os=CentOS_8
-ARG crictl_version=v1.20.0
+ARG crictl_version=v1.28.0
 
 RUN dnf update -y && dnf install -y \
     acl \
@@ -112,25 +112,12 @@ RUN if [ "$sys_arch" = "amd64" ] ; then arch_str="x86_64"; \
     && go install github.com/golang/protobuf/protoc-gen-go@latest \
     && export PATH="$PATH:$(go env GOPATH)/bin"
 
-# Install Kubectl for K8s integration-testing. Notice that we are explicitly
+# Install Kubectl for k8s-in-docker integration-testing. Notice that we are explicitly
 # stating the kubectl version to download, which should match the K8s release
-# deployed in K8s (L2) nodes.
-#
-# TODO: Define a mechanism in our testing-framework to allow K8s version to be
-# configured in a centralized location, so that the installed K8s components
-# (both inside privileged test-container and within L2 K8s image) are all
-# matching the same K8s release.
-RUN echo -e "\
-[kubernetes] \n\
-name=Kubernetes \n\
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64 \n\
-enabled=1 \n\
-gpgcheck=1 \n\
-repo_gpgcheck=1 \n\
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg \
-" > /etc/yum.repos.d/kubernetes.repo \
-    && yum update -y \
-    && yum install -y kubectl --nobest
+# deployed in the K8s-in-docker nodes (L2).
+RUN cd /tmp && curl -LO "https://dl.k8s.io/release/${k8s_version}/bin/linux/amd64/kubectl" \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl \
+    && rm /tmp/kubectl
 
 # CRI-O and crictl for testing deployment of pods with sysbox (aka "sysbox pods")
 RUN curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/${crio_os}/devel:kubic:libcontainers:stable.repo \


### PR DESCRIPTION
When installing kubectl in the test container, instead of relying on the package manager for the specific distro, download the binaries and install.

Fixes https://github.com/nestybox/sysbox/issues/895.