### PR TITLE
Add missing command to install-package.md

### DIFF
--- a/docs/user-guide/install-package.md
+++ b/docs/user-guide/install-package.md
@@ -94,6 +94,7 @@ NOTE: the `jq` tool is used by the Sysbox installer.
     associated daemons are properly running:
 
 ```console
+$ sudo systemctl status sysbox -n20
 ● sysbox.service - Sysbox container runtime
      Loaded: loaded (/lib/systemd/system/sysbox.service; enabled; vendor preset: enabled)
      Active: active (running) since Fri 2025-01-03 19:09:54 PST; 11s ago


### PR DESCRIPTION
The "Verify" section did not contain command to execute to get status of sysbox. Copied command from the section below.