### PR TITLE
Add test container based on Alpine image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ KERNEL_REL_MIN := $(shell echo $(KERNEL_REL) | cut -d'.' -f2)
 export KERNEL_REL
 
 # Sysbox image-generation globals utilized during the sysbox's building and testing process.
-ifeq ($(IMAGE_BASE_DISTRO),$(filter $(IMAGE_BASE_DISTRO),centos fedora redhat almalinux rocky amzn))
+ifeq ($(IMAGE_BASE_DISTRO),$(filter $(IMAGE_BASE_DISTRO),centos fedora redhat almalinux rocky amzn alpine))
 	IMAGE_BASE_RELEASE := $(shell cat /etc/os-release | grep "^VERSION_ID" | cut -d "=" -f2 | tr -d '"' | cut -d "." -f1)
 	KERNEL_HEADERS := kernels/$(KERNEL_REL)
 else

--- a/tests/Dockerfile.alpine-3
+++ b/tests/Dockerfile.alpine-3
@@ -1,0 +1,167 @@
+FROM alpine:3.22
+
+# K8s version for k8s-in-docker (i.e., this should be equal or greater than the
+# version of K8s running inside the k8s-in-docker container).
+ARG k8s_version=v1.28
+ARG k8s_version_full=v1.28.2
+
+# CRI-O & crictl version for testing sysbox pods; should match K8s version.
+ARG crio_version=v1.28
+ARG crictl_version=v1.28.0
+
+# Desired platform architecture to build upon.
+ARG sys_arch
+ENV SYS_ARCH=${sys_arch}
+ARG target_arch
+ENV TARGET_ARCH=${target_arch}
+
+RUN apk update && apk add \
+    alpine-sdk \
+    acl \
+    gcc \
+    musl-dev \
+    gcompat \
+    automake \
+    autoconf \
+    libtool \
+    procps-ng procps-compat \
+    psmisc \
+    nano \
+    less \
+    curl \
+    sudo \
+    gawk \
+    git \
+    iptables \
+    jq \
+    pkgconf \
+    libaio-dev \
+    libcap-dev \
+    libprotobuf \
+    protobuf \
+    protobuf-c-dev \
+    libnl3-dev \
+    libnet-dev \
+    libseccomp \
+    libseccomp-dev \
+    libseccomp-static \
+    protobuf-c-compiler \
+    protobuf-dev \
+    python3 \
+    shadow-subids \
+    kmod \
+    unzip \
+    time \
+    net-tools \
+    lsb-release-minimal \
+    wget \
+    lsof \
+    iproute2 \
+    iputils-ping \
+    ca-certificates \
+    bc \
+    openssh \
+    shellcheck \
+    gperf \
+    # sysbox deps
+    fuse \
+    rsync \
+    bash-completion \
+    attr \
+    tree \
+    shadow \
+    strace \
+    && rm -rf /var/cache/apk/* \
+    && echo ". /etc/bash_completion" >> /etc/bash.bashrc \
+    && ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa \
+    && echo "    StrictHostKeyChecking accept-new" >> /etc/ssh/ssh_config
+
+# Install Golang
+RUN wget https://go.dev/dl/go1.22.6.linux-${sys_arch}.tar.gz && \
+    tar -C /usr/local -xzf go1.22.6.linux-${sys_arch}.tar.gz && \
+    /usr/local/go/bin/go env -w GONOSUMDB=/root/nestybox
+
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+RUN go env -w GONOSUMDB=/root/nestybox && \
+    mkdir -p "$GOPATH/src" "$GOPATH/bin" && \
+    chmod -R 777 "$GOPATH"
+
+# Add a dummy user for the rootless integration tests; needed by the
+# `git clone` operations below.
+RUN useradd -u1000 -m -d/home/rootless -s/bin/bash rootless
+
+# install bats
+RUN cd /tmp \
+    && git clone https://github.com/sstephenson/bats.git \
+    && cd bats \
+    && git reset --hard 03608115df2071fff4eaaff1605768c275e5f81f \
+    && ./install.sh /usr/local \
+    && rm -rf /tmp/bats
+
+# install protoc compiler for gRPC
+RUN if [ "$sys_arch" = "amd64" ] ; then arch_str="x86_64"; \
+    elif [ "$sys_arch" = "arm64" ]; then arch_str="aarch_64"; \
+    else echo "Unsupported platform: ${sys_arch}"; exit; fi \
+    && curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-${arch_str}.zip \
+    && unzip protoc-3.15.8-linux-${arch_str}.zip -d $HOME/.local \
+    && export PATH="$PATH:$HOME/.local/bin" \
+    && go install github.com/golang/protobuf/protoc-gen-go@latest \
+    && export PATH="$PATH:$(go env GOPATH)/bin"
+
+# Install Docker
+RUN apk add --update docker openrc
+RUN rc-update add docker boot
+ADD https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker /etc/bash_completion.d/docker.sh
+
+# Go Dlv for debugging
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+# Install Kubectl for k8s-in-docker integration-testing. Notice that we are explicitly
+# stating the kubectl version to download, which should match the K8s release
+# deployed in the K8s-in-docker nodes (L2).
+RUN cd /tmp && curl -LO "https://dl.k8s.io/release/${k8s_version_full}/bin/linux/amd64/kubectl" \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl \
+    && rm /tmp/kubectl
+
+# Install the upstream CRI-O so we get the cri-o binary plus all config files,
+# etc. Later we will replace the binary with our forked Nestybox CRI-O that
+# works with Sysbox.
+#
+# Instructions: https://cri-o.io/
+RUN apk update && apk add cri-o
+
+
+# Dasel (for yaml, toml, json parsing) (https://github.com/TomWright/dasel)
+# Note: manually download Dasel v1 as our testContainerInit script does not yet support Dasel v2.
+RUN wget https://github.com/TomWright/dasel/releases/download/v1.27.2/dasel_linux_${sys_arch} &&  mv dasel_linux_${sys_arch} dasel && chmod +x dasel \
+    && mv ./dasel /usr/local/bin/dasel
+
+# K8s.io KinD
+RUN go install sigs.k8s.io/kind@v0.24.0
+
+# Use the old definition for SECCOMP_NOTIF_ID_VALID in /usr/include/linux/seccomp.h
+#
+# This is needed because the definition changed in the mainline kernel
+# on 06/2020 (from SECCOMP_IOR -> SECCOMP_IOW), and some distros we
+# support have picked it up in their latest releases / kernels
+# updates. The kernel change was backward compatible, so by using the
+# old definition, we are guaranteed it will work on kernels before and
+# after the change. On the other hand, if we were to use the new
+# definition, seccomp notify would fail when sysbox runs in old
+# kernels.
+RUN sed -i 's/^#define SECCOMP_IOCTL_NOTIF_ID_VALID[ \t]*SECCOMP_IOW(2, __u64)/#define SECCOMP_IOCTL_NOTIF_ID_VALID   SECCOMP_IOR(2, __u64)/g' /usr/include/linux/seccomp.h
+
+# sysbox env
+RUN useradd sysbox \
+    && mkdir -p /var/lib/sysboxfs
+
+# test scripts
+COPY scr/testContainerInit /usr/bin
+COPY scr/testContainerCleanup /usr/bin
+COPY scr/buildContainerInit /usr/bin
+COPY bin/userns_child_exec_${sys_arch} /usr/bin
+
+RUN mkdir -p /root/nestybox
+WORKDIR /root/nestybox/sysbox
+CMD /bin/bash


### PR DESCRIPTION
It compiles sysbox, and after configuring the host docker, and running sysbox daemons, I can do:

```
docker run --runtime=sysbox-runc --rm -it --hostname=syscont nestybox/ubuntu-bionic-systemd
```

then login with admin/admin, then:

```sql
admin@syscont:~$ sudo journalctl -xe
[sudo] password for admin: 
-- Logs begin at Sat 2025-07-12 00:46:22 UTC, end at Sat 2025-07-12 00:46:38 UTC. --
Jul 12 00:46:22 syscont systemd-journald[188]: Journal started
-- Subject: The journal has been started
-- Defined-By: systemd
-- Support: http://www.ubuntu.com/support
-- 
-- The system journal process has started up, opened the journal
-- files for writing and is now ready to process requests.
Jul 12 00:46:22 syscont systemd-journald[188]: Runtime journal (/run/log/journal/1b4e89a5b1164946adc9c370510ccd63) is 820.0K, max 6.4M, 5.6M free.
-- Subject: Disk space used by the journal
-- Defined-By: systemd
-- Support: http://www.ubuntu.com/support
-- 
-- Runtime journal (/run/log/journal/1b4e89a5b1164946adc9c370510ccd63) is currently using 820.0K.
-- Maximum allowed usage is set to 6.4M.
-- Leaving at least 9.6M free (of currently available 63.1M of disk space).
-- Enforced usage limit is thus 6.4M, of which 5.6M are still available.
-- 
-- The limits controlling how much disk space is used by the journal may
-- be configured with SystemMaxUse=, SystemKeepFree=, SystemMaxFileSize=,
-- RuntimeMaxUse=, RuntimeKeepFree=, RuntimeMaxFileSize= settings in
-- /etc/systemd/journald.conf. See journald.conf(5) for details.
Jul 12 00:46:22 syscont systemd[1]: systemd-journald.service: Failed to add fd to store: Operation not permitted
Jul 12 00:46:22 syscont systemd[1]: systemd-journald.service: Failed to add fd to store: Operation not permitted
Jul 12 00:46:22 syscont systemd[1]: systemd-journald.service: Failed to add fd to store: Operation not permitted
Jul 12 00:46:22 syscont systemd-journald[188]: Runtime journal (/run/log/journal/1b4e89a5b1164946adc9c370510ccd63) is 820.0K, max 6.4M, 5.6M free.
-- Subject: Disk space used by the journal
-- Defined-By: systemd
-- Support: http://www.ubuntu.com/support
-- 
-- Runtime journal (/run/log/journal/1b4e89a5b1164946adc9c370510ccd63) is currently using 820.0K.
-- Maximum allowed usage is set to 6.4M.
-- Leaving at least 9.6M free (of currently available 63.1M of disk space).
-- Enforced usage limit is thus 6.4M, of which 5.6M are still available.
-- 
-- The limits controlling how much disk space is used by the journal may
-- be configured with SystemMaxUse=, SystemKeepFree=, SystemMaxFileSize=,
-- RuntimeMaxUse=, RuntimeKeepFree=, RuntimeMaxFileSize= settings in
-- /etc/systemd/journald.conf. See journald.conf(5) for details.
Jul 12 00:46:22 syscont systemd[1]: systemd-journald.service: Failed to add fd to store: Operation not permitted
Jul 12 00:46:22 syscont systemd[1]: systemd-journald.service: Failed to add fd to store: Operation not permitted
Jul 12 00:46:22 syscont systemd[1]: systemd-journald.service: Failed to add fd to store: Operation not permitted
Jul 12 00:46:22 syscont systemd-resolved[295]: Positive Trust Anchors:
Jul 12 00:46:22 syscont systemd-resolved[295]: . IN DS 19036 8 2 49aac11d7b6f6446702e54a1607371607a1a41855200fd2ce1cdde32f24e8fb5
Jul 12 00:46:22 syscont systemd-resolved[295]: . IN DS 20326 8 2 e06d44b80b8f1d39a95c0b0d7c65d08458e880409bbc683457104237c7f8ec8d
Jul 12 00:46:22 syscont systemd-resolved[295]: Negative trust anchors: 10.in-addr.arpa 16.172.in-addr.arpa 17.172.in-addr.arpa 18.172.in-addr.arpa 19.172.in-addr.arpa 20.172.in-ad
dr.arpa 21.172.in-addr.arpa 22.172.in-addr.arpa 23.172.in-addr.arpa 24.172.in-addr.arpa 25.172.in-addr.arpa 26.172.in-addr.arpa 27.172.in-addr.arpa 28.172.in-addr.arpa 29.172.in-a
ddr.arpa 30.172.in-addr.arpa 31.172.in-addr.arpa 168.192.in-addr.arpa d.f.ip6.arpa corp home internal intranet lan local private test
Jul 12 00:46:22 syscont systemd-resolved[295]: Using system hostname 'syscont'.
Jul 12 00:46:22 syscont systemd-sysctl[187]: Couldn't write '1' to 'kernel/yama/ptrace_scope', ignoring: No such file or directory
Jul 12 00:46:22 syscont systemd[1]: systemd-journald.service: Failed to add fd to store: Operation not permitted
Jul 12 00:46:22 syscont systemd[1]: systemd-journald.service: Failed to add fd to store: Operation not permitted
Jul 12 00:46:22 syscont systemd-logind[460]: New seat seat0.
-- Subject: A new seat seat0 is now available
-- Defined-By: systemd
-- Support: http://www.ubuntu.com/support
-- Documentation: https://www.freedesktop.org/wiki/Software/systemd/multiseat
-- 
-- A new seat seat0 has been configured and is now available.
Jul 12 00:46:25 syscont login[474]: pam_unix(login:session): session opened for user admin by LOGIN(uid=0)
Jul 12 00:46:38 syscont sudo[505]:    admin : TTY=console ; PWD=/home/admin ; USER=root ; COMMAND=/bin/journalctl -xe
```

but `make test` errors, and among the unit tests only `make test-mgr` succeeds.