### PR TITLE
Change test containers to use fuse3.

### DIFF
--- a/tests/Dockerfile.debian-bullseye
+++ b/tests/Dockerfile.debian-bullseye
@@ -90,7 +90,7 @@ RUN apt-get update && apt-get install -y \
     bc \
     ssh-client \
     # sysbox deps
-    fuse \
+    fuse3 \
     rsync \
     bash-completion \
     attr \

--- a/tests/Dockerfile.debian-buster
+++ b/tests/Dockerfile.debian-buster
@@ -87,7 +87,7 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     ssh-client \
     # sysbox deps
-    fuse \
+    fuse3 \
     rsync \
     bash-completion \
     attr \

--- a/tests/Dockerfile.ubuntu-bionic
+++ b/tests/Dockerfile.ubuntu-bionic
@@ -92,7 +92,7 @@ RUN apt-get update && apt-get install -y \
     shellcheck \
     gperf \
     # sysbox deps
-    fuse \
+    fuse3 \
     rsync \
     bash-completion \
     attr \

--- a/tests/Dockerfile.ubuntu-focal
+++ b/tests/Dockerfile.ubuntu-focal
@@ -93,7 +93,7 @@ RUN apt-get update && apt-get install -y \
     shellcheck \
     gperf \
     # sysbox deps
-    fuse \
+    fuse3 \
     rsync \
     bash-completion \
     attr \

--- a/tests/Dockerfile.ubuntu-jammy
+++ b/tests/Dockerfile.ubuntu-jammy
@@ -93,7 +93,7 @@ RUN apt-get update && apt-get install -y \
     shellcheck \
     gperf \
     # sysbox deps
-    fuse \
+    fuse3 \
     rsync \
     bash-completion \
     attr \

--- a/tests/Dockerfile.ubuntu-noble
+++ b/tests/Dockerfile.ubuntu-noble
@@ -93,7 +93,7 @@ RUN apt-get update && apt-get install -y \
     shellcheck \
     gperf \
     # sysbox deps
-    fuse \
+    fuse3 \
     rsync \
     bash-completion \
     attr \


### PR DESCRIPTION
Sysbox-fs has been upgraded to use the last Bazil (fuse) lib, which requires the hosts support libfuse3 (all distros do since it's been around for many years already). Update the test containers to use fuse3 accordingly.