### PR TITLE
A couple of test improvements

### DIFF
--- a/tests/syscall/mount/mount.bats
+++ b/tests/syscall/mount/mount.bats
@@ -136,10 +136,10 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # a non-root user can't mount (needs cap_sys_admin)
-  docker exec "$syscont" bash -c "useradd -m -u 1000 someone"
+  docker exec "$syscont" bash -c "useradd -m -u 1001 someone"
   [ "$status" -eq 0 ]
 
-  docker exec -u 1000:1000 "$syscont" bash -c "mkdir -p /home/someone/l1/l2/proc && mount -t proc proc /home/someone/l1/l2/proc"
+  docker exec -u 1001:1001 "$syscont" bash -c "mkdir -p /home/someone/l1/l2/proc && mount -t proc proc /home/someone/l1/l2/proc"
   [ "$status" -eq 1 ]
 
   docker_stop "$syscont"
@@ -161,7 +161,7 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # add a regular user in the inner container
-  docker exec "$syscont" bash -c "useradd -u 1000 someone"
+  docker exec "$syscont" bash -c "useradd -u 1001 someone"
   [ "$status" -eq 0 ]
 
   # build the mountProcDac program inside the inner container, and install it
@@ -195,7 +195,7 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # perform the mount with mountProcDac
-  docker exec -u 1000:1000 "$syscont" bash -c "mountProcDac $mnt_path"
+  docker exec -u 1001:1001 "$syscont" bash -c "mountProcDac $mnt_path"
   [ "$status" -eq 0 ]
 
   docker_stop "$syscont"

--- a/tests/sysfs/procSys.bats
+++ b/tests/sysfs/procSys.bats
@@ -748,7 +748,7 @@ EOF
   [ "$status" -eq 0 ]
 
   # add a regular user in the inner container
-  docker exec "$syscont" bash -c "useradd -u 1000 someone"
+  docker exec "$syscont" bash -c "useradd -u 1001 someone"
   [ "$status" -eq 0 ]
 
   # build the fileDac program inside the inner container, and install it
@@ -764,18 +764,21 @@ EOF
 
   docker exec "$syscont" sh -c 'getcap /usr/bin/fileDac'
   [ "$status" -eq 0 ]
-  [[ "$output" == "/usr/bin/fileDac = cap_dac_override,cap_dac_read_search+p" ]]
+  # getcap output format varies by libcap version:
+  #   old:  "/usr/bin/fileDac = cap_dac_override,cap_dac_read_search+p"
+  #   new:  "/usr/bin/fileDac cap_dac_override,cap_dac_read_search=p"
+  [[ "$output" =~ ^/usr/bin/fileDac(\ =)?\ cap_dac_override,cap_dac_read_search[+=]p$ ]]
 
   # write to /proc/sys as a regular user; should fail
-  docker exec -u 1000:1000 "$syscont" bash -c "echo 0 > /proc/sys/net/ipv4/ip_forward"
+  docker exec -u 1001:1001 "$syscont" bash -c "echo 0 > /proc/sys/net/ipv4/ip_forward"
   [ "$status" -eq 1 ]
 
   # write to /proc/sys as a regular use, but using the fileDac program
   # (should pass because the program sets the DAC* caps).
-  docker exec -u 1000:1000 "$syscont" bash -c "fileDac write /proc/sys/net/ipv4/ip_forward 0"
+  docker exec -u 1001:1001 "$syscont" bash -c "fileDac write /proc/sys/net/ipv4/ip_forward 0"
   [ "$status" -eq 0 ]
 
-  docker exec -u 1000:1000 "$syscont" bash -c "fileDac read /proc/sys/net/ipv4/ip_forward"
+  docker exec -u 1001:1001 "$syscont" bash -c "fileDac read /proc/sys/net/ipv4/ip_forward"
   [ "$status" -eq 0 ]
   [ "$output" -eq 0 ]
 


### PR DESCRIPTION
These are required by changes to the `ubuntu:latest` image used by several tests. 

- Relax getcap assertion to accept both old "path = caps+p" and new
  "path caps=p" formats (libcap output changed).

- Use uid 1001 for the unprivileged test user; uid 1000 is now the
  default "ubuntu" user in ubuntu:resolute and later.